### PR TITLE
Add detailed Part 2 to README.md for Dojo setup, resolves #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,146 @@ Join our **Telegram group** for discussions and updates.
 
 ---
 
+## Part 2: Installing Dojo and Its Tools
 
+This section covers the installation and setup of the Dojo Engine and its tools, assuming `asdf` is already installed (see Part 1).
+
+### Prerequisites
+- Git and Curl installed.
+- Rust (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`).
+- A cloned repo: `git clone https://github.com/krishnabandewar/ODBuild.git && cd ODBuild`.
+
+### Installation Steps
+1. **Install Dojo with `dojoup`**:
+   ```bash
+   curl -L https://install.dojoengine.org | bash
+   source ~/.bashrc  # Reload shell
+   dojoup --version  # Verify
+Installs sozo, katana, and torii.
+Build the Project:
+
+sozo build
+Run Locally with Katana:
+
+katana --chain-id TEST
+Deploy to Katana: In a new terminal:
+
+sozo migrate
+Query with Torii (optional):
+
+torii --world <WORLD_ADDRESS>
+Access at http://localhost:8080/graphql.
+Troubleshooting
+No Scarb.toml? Run sozo init and add dojo = "0.6.0" to Scarb.toml.
+Windows? Use WSL2.
+Questions? Ping @lemonade46 on Telegram.
+
+## Part 2: Installing Dojo and Its Tools
+
+This section provides a detailed guide to installing and setting up the Dojo Engine and its associated tools (`sozo`, `katana`, and `torii`). It assumes you’ve already installed `asdf` as described in Part 1 of this README. These steps are based on the official Dojo Engine documentation ([dojoengine.org/getting-started](https://www.dojoengine.org/getting-started)).
+
+### Prerequisites
+
+Before starting, ensure the following are set up on your system:
+- **Git**: For cloning the repository. Install with:
+  - Ubuntu: `sudo apt install git`
+  - macOS: `brew install git`
+  - Verify: `git --version` (e.g., "git version 2.34.1")
+- **Curl**: For downloading the installer. Install with:
+  - Ubuntu: `sudo apt install curl`
+  - macOS: `brew install curl`
+  - Verify: `curl --version` (e.g., "curl 7.81.0")
+- **Rust**: Required for compiling Dojo components. Install with:
+  ```bash
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  source $HOME/.cargo/env
+  rustc --version  # Should return something like "rustc 1.75.0"
+  ```
+- **Cloned Repository**: Clone your fork of the project:
+  ```bash
+  git clone https://github.com/krishnabandewar/ODBuild.git
+  cd ODBuild
+  ```
+  - Replace `ODBuild` with the actual repository name if different. Confirm it worked by running `ls` (or `dir` on WSL) to see the project files.
+
+**Note**: These steps assume a Unix-based system (Linux/macOS). For Windows, install WSL2 (Windows Subsystem for Linux) with `wsl --install` in PowerShell and use a WSL terminal.
+
+### Installation Steps
+
+#### 1. Install Dojo with `dojoup`
+
+The easiest way to install Dojo and its tools is via `dojoup`, a single-command installer.
+- Run:
+  ```bash
+  curl -L https://install.dojoengine.org | bash
+  ```
+  - This command fetches and executes a script from the Dojo Engine site to install the Dojo binaries in your home directory (e.g., `~/.dojo/bin`).
+- Reload your shell to update the PATH:
+  ```bash
+  source ~/.bashrc  # Use ~/.zshrc if you’re on Zsh
+  ```
+  - This ensures your terminal recognizes the newly installed commands.
+- Verify installation:
+  ```bash
+  dojoup --version  # Example output: "dojoup 0.6.0"
+  ```
+  - **What this does**: Installs `sozo` (project manager), `katana` (local blockchain), and `torii` (indexer). You can confirm these are installed by running `sozo --version`, `katana --version`, and `torii --version`.
+
+#### 2. Build the Project
+
+Compile the Dojo project in your repository:
+- Run:
+  ```bash
+  sozo build
+  ```
+  - **What this does**: Uses `sozo` to compile any Cairo code in the project (e.g., in `src/` directory) into executable artifacts stored in the `target/` directory.
+  - **Expected Output**: A success message like "Successfully built project." If there’s no Cairo code yet, you might see an error—see Troubleshooting below.
+
+#### 3. Run Locally with Katana
+
+Test your project on a local blockchain using `katana`:
+- Run:
+  ```bash
+  katana --chain-id TEST
+  ```
+  - **What this does**: Starts a local Dojo blockchain node for development. Keep this terminal running; you’ll see logs indicating the node is active (e.g., "Listening on 0.0.0.0:5050").
+
+#### 4. Deploy to Katana
+
+Deploy your project to the local blockchain:
+- In a new terminal (from the repo directory):
+  ```bash
+  sozo migrate
+  ```
+  - **What this does**: Deploys the compiled artifacts to the running Katana node.
+  - **Expected Output**: Includes a "World address" (e.g., `0x1234...`). Save this address for the next step.
+
+#### 5. Query with Torii (Optional)
+
+Index and query your deployed project with `torii`:
+- Run:
+  ```bash
+  torii --world <WORLD_ADDRESS>
+  ```
+  - Replace `<WORLD_ADDRESS>` with the address from `sozo migrate`.
+  - **What this does**: Starts an indexer to track on-chain data and provides a GraphQL API.
+  - Access the GraphQL interface at: `http://localhost:8080/graphql`. Test it by opening the URL in a browser or using a GraphQL client (e.g., Postman).
+
+### Troubleshooting
+
+- **Missing `Scarb.toml`?**
+  - If your repo lacks a `Scarb.toml` file, initialize a Dojo project:
+    ```bash
+    sozo init
+    ```
+  - Edit `Scarb.toml` to include:
+    ```toml
+    [dependencies]
+    dojo = "0.6.0"
+    ```
+- **Command Not Found?**
+  - Ensure your PATH is updated: `export PATH="$HOME/.dojo/bin:$PATH"`.
+  - Reload your shell (`source ~/.bashrc`) or restart your terminal.
+- **Windows Users**: Use WSL2 (install via `wsl --install` in PowerShell).
+- **Still Stuck?** Contact `@lemonade46` on Telegram or join the TVA group.
 


### PR DESCRIPTION
Added detailed installation and setup instructions for Dojo and its tools (`sozo`, `katana`, `torii`) as requested in issue #9. Includes:
- Prerequisites with installation commands
- Step-by-step setup process
- Troubleshooting tips
Resolves #9