### PR TITLE
Implemented `compare_hands` and restructured code for PlayerTrait.

### DIFF
--- a/poker-texas-hold-em/GameREADME.md
+++ b/poker-texas-hold-em/GameREADME.md
@@ -41,3 +41,27 @@ player's hand = 1, 2
 community card = 3, 4, 5, 6, 7
 
 then the hand rank should return 3, 4, 5, 6, 7
+
+
+// fn extract_kicker(hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>,
+// Array<Card>)
+// implement kicker. Only works for the current_winner variable
+// retrieve the former current_winner already stored and the current player,
+// and compare both hands. This should be done in another internal function and be
+                // called here.
+                // The function should take in both `hand` and `current_winning_hand`, should return
+                // the winning hand Implementation would be left to you
+                // compare the player's CA in the returned hand to the current `winning_hand`
+                // If not equal, update both `current_winner` and `winning_hand`
+
+                // TODO: Check for a straight. The kicker is different for a straight. The person
+                // with the highest straight wins (compare only the last straight.) The function
+                // called here might take in a `hand_rank` u16 variable to check for this.
+
+                // in rare case scenarios, a pot can be split based on the game params
+                // here, an array shall be used. check kicker_split, if true, add two same hands in
+                // the array Add the kicker hand first into the array, before the other...that's if
+                // `game_params.kicker_split`
+                // is true, if not, add only the kicker hand to the Array. For more than two
+                // kickers, arrange the array accordingly. might be implemented by someone else.
+                // here, hands have been changed, right?

--- a/poker-texas-hold-em/contract/src/lib.cairo
+++ b/poker-texas-hold-em/contract/src/lib.cairo
@@ -13,9 +13,11 @@ mod models {
 }
 
 mod traits {
+    mod handtrait;
     mod game;
-    mod hand;
+    mod handimpl;
     mod deck;
+    mod player;
 }
 
 mod tests {

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -1,6 +1,6 @@
 use starknet::ContractAddress;
 use super::card::Card;
-use poker::traits::hand::HandTrait;
+use poker::traits::handimpl::HandImpl;
 
 /// Created once and for all for every available player.
 #[derive(Serde, Drop, Clone, Debug)]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -1,6 +1,6 @@
 use starknet::ContractAddress;
 use super::card::Card;
-use poker::traits::handimpl::HandImpl;
+use poker::traits::handtrait::HandTrait;
 
 /// Created once and for all for every available player.
 #[derive(Serde, Drop, Clone, Debug)]

--- a/poker-texas-hold-em/contract/src/models/player.cairo
+++ b/poker-texas-hold-em/contract/src/models/player.cairo
@@ -2,6 +2,7 @@ use starknet::ContractAddress;
 use core::num::traits::Zero;
 use super::base::GameErrors;
 use super::game::{Game, GameTrait, GameMode};
+use poker::traits::player::PlayerTrait;
 
 // the locked variable takes in a tuple of (is_locked, game_id) if the player is already
 // locked to a session.
@@ -42,55 +43,6 @@ pub fn get_default_player() -> Player {
     }
 }
 
-#[generate_trait]
-pub impl PlayerImpl of PlayerTrait {
-    fn exit(ref self: Player, ref game: Game, out: bool) {
-        let (is_locked, id) = self.locked;
-        assert(is_locked, 'CANNOT EXIT, PLAYER NOT LOCKED');
-        assert(game.current_player_count != 0, 'GAME PLAYER COUNT SUB');
-        if out {
-            // check game id
-            assert(id == game.id, 'BAD REQUEST');
-            self.out = (game.id, game.reshuffled);
-        }
-
-        self.current_bet = 0;
-        self.is_dealer = false;
-        self.in_round = false;
-        self.locked = (false, 0);
-        self.out = (0, 0);
-
-        game.current_player_count -= 1;
-    }
-
-    fn enter(ref self: Player, ref game: Game) {
-        let (is_locked, _) = self.locked;
-        assert(!is_locked, GameErrors::PLAYER_ALREADY_LOCKED);
-        // Ensure player has enough chips for the game
-        assert(self.chips >= game.params.min_amount_of_chips, GameErrors::INSUFFICIENT_CHIP);
-        assert(game.is_initialized(), GameErrors::GAME_NOT_INITIALIZED);
-        assert(!game.has_ended, GameErrors::GAME_ALREADY_ENDED);
-        assert(game.is_allowable(), GameErrors::ENTRY_DISALLOWED);
-
-        if (game.id, game.reshuffled) != self.out {
-            // append. Player doesn't exist in the game
-            game.players.append(self.id);
-        } // should work.
-        self.locked = (true, game.id);
-        self.in_round = true;
-        game.current_player_count += 1;
-    }
-
-    fn extract_current_game_id(self: @Player) -> @u64 {
-        let (is_locked, game_id) = self.locked;
-        assert(*is_locked, GameErrors::PLAYER_NOT_IN_GAME);
-        assert(*game_id != 0, GameErrors::PLAYER_NOT_IN_GAME);
-
-        game_id
-    }
-
-    fn is_in_game(self: @Player, game_id: u64) -> bool {
-        let (is_locked, id) = self.locked;
-        *is_locked && id == @game_id
-    }
-}
+/// TESTS ON PLAYER MODEL
+#[cfg(test)]
+mod tests {}

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -13,7 +13,7 @@ pub mod actions {
     use poker::models::card::{Card, CardTrait};
     use poker::models::deck::{Deck, DeckTrait};
     use poker::models::game::{Game, GameMode, GameParams, GameTrait};
-    use poker::models::hand::{Hand, HandTrait};
+    use poker::models::hand::{Hand, HandImpl};
     use poker::models::player::{Player, PlayerTrait, get_default_player};
     use poker::traits::game::get_default_game_params;
     use super::super::interface::IActions;
@@ -70,23 +70,6 @@ pub mod actions {
                         time_stamp: starknet::get_block_timestamp(),
                     },
                 );
-
-            // extracted default GameParams from traits::game
-            // let default_param = get_default_game_params();
-
-            // match game_params {
-            //     Option::Some(value) => {
-            //     world.emit_event(@GameInitialized {
-            //         game_id: game_id,
-            //         player: caller,
-            //         game_params: value,
-            //     })},
-            //     Option::None => world.emit_event(@GameInitialized{
-            //         game_id: game_id,
-            //         player: caller,
-            //         game_params: default_param,
-            //     }),
-            // };
 
             game_id
         }

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -13,7 +13,7 @@ pub mod actions {
     use poker::models::card::{Card, CardTrait};
     use poker::models::deck::{Deck, DeckTrait};
     use poker::models::game::{Game, GameMode, GameParams, GameTrait};
-    use poker::models::hand::{Hand, HandImpl};
+    use poker::models::hand::{Hand, HandTrait};
     use poker::models::player::{Player, PlayerTrait, get_default_player};
     use poker::traits::game::get_default_game_params;
     use super::super::interface::IActions;

--- a/poker-texas-hold-em/contract/src/traits/handimpl.cairo
+++ b/poker-texas-hold-em/contract/src/traits/handimpl.cairo
@@ -120,7 +120,7 @@ pub impl HandImpl of HandTrait {
                 winning_new_hands, highest_rank,
             );
 
-            if game_params.kicker_split == true {
+            if game_params.kicker_split {
                 // the player address of each hand should be valid
                 for hand in kicker_hands {
                     // the hand.player should be valid

--- a/poker-texas-hold-em/contract/src/traits/handimpl.cairo
+++ b/poker-texas-hold-em/contract/src/traits/handimpl.cairo
@@ -6,43 +6,18 @@ use core::num::traits::{Zero, One};
 use core::dict::Felt252DictTrait;
 use core::array::ArrayTrait;
 use core::option::OptionTrait;
-
-pub trait HandTrait {
-    fn default() -> Hand;
-    fn new_hand(ref self: Hand);
-    fn rank(self: @Hand, community_cards: Array<Card>) -> (Hand, u16);
-    fn compare_hands(
-        hands: Array<Hand>, community_cards: Array<Card>, game_params: GameParams,
-    ) -> Span<(Hand, Card)>;
-    fn remove_card(ref self: Hand, pos: usize) -> Card;
-    fn reveal(self: @Hand) -> Span<Card>;
-    fn add_card(ref self: Hand, card: Card);
-    fn get_hand_bytearray(self: @Hand) -> ByteArray;
-    // TODO, add function that shows cards in bytearray, array of tuple (suit, and value)
-// add to card trait.
-}
+use super::handtrait::HandTrait;
 
 pub impl HandImpl of HandTrait {
-    /// Evaluates the rank of a player's hand by combining their cards with community cards
-    ///
-    /// This function determines the highest-ranking 5-card hand possible using the player's
-    /// cards and the community cards. It generates all possible 5-card combinations and
-    /// evaluates each to find the best hand and its corresponding rank.
-    ///
-    /// # Arguments
-    /// * `self` - A reference to the current Hand
-    /// * `community_cards` - An array of community cards to combine with the player's hand
-    ///
-    /// # Returns
-    /// A tuple containing:
-    /// 1. A new Hand with the best 5 cards found
-    /// 2. The rank of the hand as a u16 (using HandRank constants)
-    ///
-    /// # Panics
-    /// Panics if the total number of cards is not exactly 7
-    ///
-    /// # Author
-    /// [@pope-h]
+    fn default() -> Hand {
+        Hand { player: Zero::zero(), cards: array![] }
+    }
+
+    fn new_hand(ref self: Hand) {
+        self.cards = array![];
+    }
+
+    /// @pope-h
     fn rank(self: @Hand, community_cards: Array<Card>) -> (Hand, u16) {
         // this function can be called externally in the future.
         // (Self::default(), 0) // Temporary return value
@@ -115,65 +90,57 @@ pub impl HandImpl of HandTrait {
         (best_hand, best_rank)
     }
 
-    /// This function will compare the hands of all the players and return an array of Player
-    /// contains the player with the winning hand
-    /// this is only possible if the `kick_split` in game_params is true
+    /// @Birdmannn
     fn compare_hands(
         hands: Array<Hand>, community_cards: Array<Card>, game_params: GameParams,
-    ) -> Span<(Hand, Card)> {
-        // for hand comparisons, there should be a kicker
-        // kicker there-in that there are times two or more players have the same hand rank, so we
-        // check the value of each card in hand.
-
-        // add ratio to the returned span
-
-        // TODO: Ace might be changed to a higher value.
+    ) -> (Span<Hand>, u16, Span<Card>) {
         let mut highest_rank: u16 = 0;
-        let mut current_winning_hand: Hand = Self::default();
-        // let mut winning_players: Array<Option<Player>> = array![];
-        let mut winning_hands: Array<(Hand, Card)> = array![];
+        let mut winning_hands: Array<Hand> = array![];
+        let mut winning_new_hands: Array<Hand> = array![];
+        let mut kicker_cards: Array<Card> = array![];
+
         for hand in hands {
-            let (new_hand, current_rank) = hand.rank(community_cards.clone());
+            let (new_hand, current_rank): (Hand, u16) = hand.rank(community_cards.clone());
             if current_rank > highest_rank {
                 highest_rank = current_rank;
-                current_winning_hand = hand;
-                // append details into `winning_hands` -- extracted using a bool variables
-                // `hands_changed`
-                // the hands have been changed
-                winning_hands = array![];
-                // update the necessary arrays here.
-
+                winning_hands = array![hand];
+                winning_new_hands = array![new_hand];
             } else if current_rank == highest_rank {
-                // implement kicker. Only works for the current_winner variable
-                // retrieve the former current_winner already stored and the current player,
-                // and compare both hands. This should be done in another internal function and be
-                // called here.
-                // The function should take in both `hand` and `current_winning_hand`, should return
-                // the winning hand Implementation would be left to you
-                // compare the player's CA in the returned hand to the current `winning_hand`
-                // If not equal, update both `current_winner` and `winning_hand`
-
-                // TODO: Check for a straight. The kicker is different for a straight. The person
-                // with the highest straight wins (compare only the last straight.) The function
-                // called here might take in a `hand_rank` u16 variable to check for this.
-
-                // in rare case scenarios, a pot can be split based on the game params
-                // here, an array shall be used. check kicker_split, if true, add two same hands in
-                // the array Add the kicker hand first into the array, before the other...that's if
-                // `game_params.kicker_split`
-                // is true, if not, add only the kicker hand to the Array. For more than two
-                // kickers, arrange the array accordingly. might be implemented by someone else.
-                // here, hands have been changed, right?
-                winning_hands = array![];
-                // do the necessary updates.
+                winning_hands.append(hand);
+                winning_new_hands.append(new_hand);
             }
         };
 
-        winning_hands.span()
-    }
+        // if winning_hands.len() > 1, then it kicked. Extract kicker
+        // add all hands into the array if game_params.kicker_split is true.
+        // else add only the kicking hand.
+        if winning_hands.len() > 1 {
+            let mut hands: Array<Hand> = array![];
+            let (kicker_hands, _cards): (Array<Hand>, Array<Card>) = extract_kicker(
+                winning_new_hands, highest_rank,
+            );
 
-    fn new_hand(ref self: Hand) {
-        self.cards = array![];
+            if game_params.kicker_split == true {
+                // the player address of each hand should be valid
+                for hand in kicker_hands {
+                    // the hand.player should be valid
+                    assert(hand.player != Zero::zero(), 'EXTRACTION ERROR');
+                    for i in 0..winning_hands.len() {
+                        let w = winning_hands.at(i);
+                        if hand.player == *w.player {
+                            let wh = Hand { player: hand.player, cards: w.cards.clone() };
+                            hands.append(wh);
+                            break;
+                        }
+                    }
+                };
+                kicker_cards = _cards;
+            }
+
+            winning_hands = hands;
+        }
+
+        (winning_hands.span(), highest_rank, kicker_cards.span())
     }
 
     fn remove_card(ref self: Hand, pos: usize) -> Card {
@@ -193,10 +160,6 @@ pub impl HandImpl of HandTrait {
 
     fn add_card(ref self: Hand, card: Card) { // ensure card is added.
         self.cards.append(card);
-    }
-
-    fn default() -> Hand {
-        Hand { player: Zero::zero(), cards: array![] }
     }
 
     fn get_hand_bytearray(self: @Hand) -> ByteArray {
@@ -220,6 +183,8 @@ pub impl HandImpl of HandTrait {
 ///
 /// returns a tuple of an array of the winning hands, and an array of the cards that did the kicking
 /// The card in the winning hands are always equal
+/// The hand returned here is usually one...unless all hands taken in as the parameter were exactly
+/// equal.
 fn extract_kicker(hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array<Card>) {
     // Implement kicker based on hand_rank
     // some hand_ranks have a different kicker implementation from the rest

--- a/poker-texas-hold-em/contract/src/traits/handtrait.cairo
+++ b/poker-texas-hold-em/contract/src/traits/handtrait.cairo
@@ -1,0 +1,63 @@
+use poker::models::hand::Hand;
+use poker::models::card::Card;
+use poker::models::game::GameParams;
+
+pub trait HandTrait {
+    /// Returns a default empty hand with a zero player address
+    fn default() -> Hand;
+
+    /// Reinitializes the target hand.
+    ///
+    /// This function reinitializes the target hand with it's existing player address, but with
+    /// an empty array of cards.
+    fn new_hand(ref self: Hand);
+
+    /// @pope-h
+    /// Evaluates the rank of a player's hand by combining their cards with community cards
+    ///
+    /// This function determines the highest-ranking 5-card hand possible using the player's
+    /// cards and the community cards. It generates all possible 5-card combinations and
+    /// evaluates each to find the best hand and its corresponding rank.
+    ///
+    /// # Arguments
+    /// * `self` - A reference to the current Hand
+    /// * `community_cards` - An array of community cards to combine with the player's hand
+    ///
+    /// # Returns
+    /// A tuple containing:
+    /// 1. A new Hand with the best 5 cards found
+    /// 2. The rank of the hand as a u16 (using HandRank constants)
+    ///
+    /// # Panics
+    /// Panics if the total number of cards is not exactly 7
+    fn rank(self: @Hand, community_cards: Array<Card>) -> (Hand, u16);
+
+    /// @Birdmannn
+    /// Compares all hands combined with the community cards in the game to evaluate the highest of
+    /// them all
+    ///
+    /// This function determines the highest card combo in all cards passed into it, combined with
+    /// the community cards.
+    ///
+    /// # Arguments
+    /// * `hands` - An array of hands to be compared.
+    /// * `community_cards` - And array of the community cards to be used for the coombination per
+    /// hand * `game_params` - The game params for checks to determine the right return values. It
+    /// checks the `kicker_split` value and the return value is based on that value
+    ///
+    /// # Returns
+    /// A tuple containing
+    /// 1. A Span of Winning Hands that comes out alive from the Array inputted in the params
+    /// 2. The `HandRank` value of the corresponding Hands... All Hands returned are always equal in
+    /// rank
+    /// 3. The Span of cards that did the kicking. This will be used by the splitting logic to
+    /// split the pot based on the ratio extracted from the returned kicker cards.
+    /// The len > 0 only if game_params.kicker_split is true.
+    fn compare_hands(
+        hands: Array<Hand>, community_cards: Array<Card>, game_params: GameParams,
+    ) -> (Span<Hand>, u16, Span<Card>);
+    fn remove_card(ref self: Hand, pos: usize) -> Card;
+    fn reveal(self: @Hand) -> Span<Card>;
+    fn add_card(ref self: Hand, card: Card);
+    fn get_hand_bytearray(self: @Hand) -> ByteArray;
+}

--- a/poker-texas-hold-em/contract/src/traits/handtrait.cairo
+++ b/poker-texas-hold-em/contract/src/traits/handtrait.cairo
@@ -1,6 +1,7 @@
 use poker::models::hand::Hand;
 use poker::models::card::Card;
 use poker::models::game::GameParams;
+use super::handimpl::HandImpl;
 
 pub trait HandTrait {
     /// Returns a default empty hand with a zero player address

--- a/poker-texas-hold-em/contract/src/traits/player.cairo
+++ b/poker-texas-hold-em/contract/src/traits/player.cairo
@@ -1,0 +1,57 @@
+use poker::models::player::Player;
+use poker::models::game::Game;
+use poker::models::base::GameErrors;
+use super::game::GameTrait;
+
+#[generate_trait]
+pub impl PlayerImpl of PlayerTrait {
+    fn exit(ref self: Player, ref game: Game, out: bool) {
+        let (is_locked, id) = self.locked;
+        assert(is_locked, 'CANNOT EXIT, PLAYER NOT LOCKED');
+        assert(game.current_player_count != 0, 'GAME PLAYER COUNT SUB');
+        if out {
+            // check game id
+            assert(id == game.id, 'BAD REQUEST');
+            self.out = (game.id, game.reshuffled);
+        }
+
+        self.current_bet = 0;
+        self.is_dealer = false;
+        self.in_round = false;
+        self.locked = (false, 0);
+        self.out = (0, 0);
+
+        game.current_player_count -= 1;
+    }
+
+    fn enter(ref self: Player, ref game: Game) {
+        let (is_locked, _) = self.locked;
+        assert(!is_locked, GameErrors::PLAYER_ALREADY_LOCKED);
+        // Ensure player has enough chips for the game
+        assert(self.chips >= game.params.min_amount_of_chips, GameErrors::INSUFFICIENT_CHIP);
+        assert(game.is_initialized(), GameErrors::GAME_NOT_INITIALIZED);
+        assert(!game.has_ended, GameErrors::GAME_ALREADY_ENDED);
+        assert(game.is_allowable(), GameErrors::ENTRY_DISALLOWED);
+
+        if (game.id, game.reshuffled) != self.out {
+            // append. Player doesn't exist in the game
+            game.players.append(self.id);
+        } // should work.
+        self.locked = (true, game.id);
+        self.in_round = true;
+        game.current_player_count += 1;
+    }
+
+    fn extract_current_game_id(self: @Player) -> @u64 {
+        let (is_locked, game_id) = self.locked;
+        assert(*is_locked, GameErrors::PLAYER_NOT_IN_GAME);
+        assert(*game_id != 0, GameErrors::PLAYER_NOT_IN_GAME);
+
+        game_id
+    }
+
+    fn is_in_game(self: @Player, game_id: u64) -> bool {
+        let (is_locked, id) = self.locked;
+        *is_locked && id == @game_id
+    }
+}


### PR DESCRIPTION
## Overview
`compare_hands` is the function called after every round is resolved. It is used for the `showdown` of the poker game. This function takes in an array of Player's hands to be compared, and takes in an array of the current community cards in the game, and performs a  **showdown**
Closes #61 

## Implementation
This function calls the `rank` of each hand, for each hand passed in the array, and stores the hand that has the greatest rank. If the current rank is equal to that of the stored greatest, it appends it into the already `winning_hands` array. If no other checks invalidates this array, the highest of all winning hands must be gotten, so `extract_kicker` is called, which is a function that takes in the array of winning hands, and returns the actual winning hands.

Original hands are resolved, and the return value is dependent on the game_params. if `game_params.kicker_split` is true, then we must optimize the return value with all hands and kicker cards.

A Span of all hands, kicker cards, and the `HnadRank` are returned

## Rules followed
- Code was strongly typed
- Test functions would be carried out immediately, and all bugs found would be killed immediately
- `HandTrait` was extracted into a different file to accommodate documentation of each function
- Function was properly documented as stated in the issue.