### PR TITLE
Adjust rank function

### DIFF
--- a/poker-texas-hold-em/contract/src/traits/handimpl.cairo
+++ b/poker-texas-hold-em/contract/src/traits/handimpl.cairo
@@ -62,8 +62,7 @@ pub impl HandImpl of HandTrait {
         // If only one hand has the best rank, return it directly
         if best_hands.len() == 1 {
             let best_hand = Hand {
-                player: *self.player,
-                cards: clone_array(best_hands.at(0).cards)
+                player: *self.player, cards: clone_array(best_hands.at(0).cards),
             };
             return (best_hand, best_rank.into());
         }
@@ -71,10 +70,7 @@ pub impl HandImpl of HandTrait {
         // Multiple hands with the same rank; use extract_kicker to determine the best
         let (winning_hands, _) = extract_kicker(best_hands, best_rank);
         let best_hand = if winning_hands.len() > 0 {
-            Hand {
-                player: *self.player,
-                cards: clone_array(winning_hands.at(0).cards)
-            }
+            Hand { player: *self.player, cards: clone_array(winning_hands.at(0).cards) }
         } else {
             // Fallback: create a default hand
             Hand { player: Zero::zero(), cards: array![] }

--- a/poker-texas-hold-em/contract/src/traits/handimpl.cairo
+++ b/poker-texas-hold-em/contract/src/traits/handimpl.cairo
@@ -74,9 +74,8 @@ pub impl HandImpl of HandTrait {
             };
             return (best_hand, best_rank.into());
         }
-        let best_hand = Hand { 
-            player: *self.player, 
-            cards: clone_array(winning_hands.at(0).cards) 
+        let best_hand = Hand {
+            player: *self.player, cards: clone_array(winning_hands.at(0).cards),
         };
 
         (best_hand, best_rank.into())
@@ -336,7 +335,7 @@ fn evaluate_five_cards(cards: Array<Card>) -> (Array<Card>, HandRank) {
     // Count values for pairs, three of a kind, etc., using original_values
     let mut value_counts: Felt252Dict<u8> = Default::default();
     let values = array![orig_val0, orig_val1, orig_val2, orig_val3, orig_val4];
-   
+
     for i in 0..values.len() {
         let val = *values.at(i);
         value_counts.insert(val.into(), value_counts.get(val.into()) + 1);


### PR DESCRIPTION
This closes #90 

# Refined Poker Hand Ranking Implementation

## Core Functionality
- The function has been enhanced to ensure the best possible 5-card hand is returned by incorporating tie-breaking logic and addressing Cairo-specific type constraints:

## Evaluation Strategy
Modified to handle ties among highest-ranking hands:

- Now tracks all hands with the maximum rank, not just the first encountered
- Integrates extract_kicker to select the optimal hand from equal-rank combinations
- Ensures the highest-value hand (e.g., best straight) is returned

## Technical Innovations
### Tie-Breaking Logic
Added sophisticated tie resolution:

- Collects multiple hands of equal rank in an array
- Uses extract_kicker to determine the best hand based on poker tie-breaking rules
- Resolves limitation where only the first highest-rank hand was retained

### Ownership and Type Safety
Adapted to Cairo’s ownership and snapshot system:

- Replaced invalid desnapping of Hand with manual construction
- Uses *self.player consistently to avoid ContractAddress type mismatches
- Ensures proper ownership transfer without violating Cairo constraints

### Clone Array Helper
Introduced clone_array to support array handling:

- Duplicates Array<Card> from snapshots for Hand construction
- Addresses non-copyable Array type limitations in Cairo
- Ensures returned Hand owns its cards

## Robustness Improvements
Enhanced edge-case handling:

- Returns a single hand directly when no ties occur
- Provides a default hand fallback if extract_kicker returns no winners
- Maintains player consistency across all returned hands