### PR TITLE
feat: leave_game and resolve_game

### DIFF
--- a/poker-texas-hold-em/contract/src/models/base.cairo
+++ b/poker-texas-hold-em/contract/src/models/base.cairo
@@ -63,6 +63,17 @@ pub struct PlayerJoined {
     pub expected_no_of_players: u32,
 }
 
+#[derive(Drop, Serde)]
+#[dojo::event]
+pub struct PlayerLeft {
+    #[key]
+    pub game_id: u64,
+    #[key]
+    pub player_id: ContractAddress,
+    pub player_count: u32,
+    pub expected_no_of_players: u32,
+}
+
 /// MODEL
 
 #[derive(Serde, Copy, Drop, PartialEq)]

--- a/poker-texas-hold-em/contract/src/models/base.cairo
+++ b/poker-texas-hold-em/contract/src/models/base.cairo
@@ -50,6 +50,8 @@ pub struct RoundResolved {
     #[key]
     pub game_id: u64,
     pub can_join: bool,
+    pub winners: Array<ContractAddress>,
+    pub pot: u256,
 }
 
 #[derive(Drop, Serde)]
@@ -72,6 +74,15 @@ pub struct PlayerLeft {
     pub player_id: ContractAddress,
     pub player_count: u32,
     pub expected_no_of_players: u32,
+}
+
+#[derive(Drop, Serde)]
+#[dojo::event]
+pub struct GameConcluded {
+    #[key]
+    pub game_id: u64,
+    pub time_stamp: u64,
+    pub mvp: ContractAddress,
 }
 
 /// MODEL

--- a/poker-texas-hold-em/contract/src/models/game.cairo
+++ b/poker-texas-hold-em/contract/src/models/game.cairo
@@ -18,6 +18,7 @@ pub enum GameMode {
 #[derive(Copy, Drop, Serde, Default, Introspect, PartialEq)]
 pub struct GameParams {
     game_mode: GameMode,
+    ownable: Option<ContractAddress>,
     max_no_of_players: u32,
     small_blind: u64,
     big_blind: u64,
@@ -53,6 +54,7 @@ pub struct Game {
     in_progress: bool,
     has_ended: bool,
     current_round: u8,
+    should_end: bool,
     round_in_progress: bool,
     current_player_count: u32,
     players: Array<ContractAddress>,

--- a/poker-texas-hold-em/contract/src/models/player.cairo
+++ b/poker-texas-hold-em/contract/src/models/player.cairo
@@ -9,7 +9,7 @@ use poker::traits::player::PlayerTrait;
 // Hand should be a reference.
 
 // FOR NOW, NO PLAYER CAN HAVE MORE THAN ONE HAND.
-// Go to all funcrtions that use player as a parameter, and remove the snapshot
+// Go to all functions that use player as a parameter, and remove the snapshot
 #[derive(Drop, Serde, Debug, Hash)]
 #[dojo::model]
 pub struct Player {

--- a/poker-texas-hold-em/contract/src/systems/interface.cairo
+++ b/poker-texas-hold-em/contract/src/systems/interface.cairo
@@ -20,7 +20,7 @@ trait IActions<TContractState> {
     fn initialize_game(ref self: TContractState, game_params: Option<GameParams>) -> u64;
     fn join_game(ref self: TContractState, game_id: u64);
     fn leave_game(ref self: TContractState);
-    fn end_game(ref self: TContractState, game_id: u64);
+    fn end_game(ref self: TContractState, game_id: u64, force: bool);
 
     /// ********************************* NOTE *************************************************
     ///

--- a/poker-texas-hold-em/contract/src/traits/game.cairo
+++ b/poker-texas-hold-em/contract/src/traits/game.cairo
@@ -56,9 +56,11 @@ pub impl GameImpl of GameTrait {
     fn append() {}
 }
 
-pub fn get_default_game_params() -> GameParams {
+
+fn get_default_game_params() -> GameParams {
     GameParams {
         game_mode: Default::default(),
+        ownable: Option::None,
         max_no_of_players: 5,
         small_blind: 10,
         big_blind: 20,

--- a/poker-texas-hold-em/contract/src/traits/player.cairo
+++ b/poker-texas-hold-em/contract/src/traits/player.cairo
@@ -8,18 +8,19 @@ pub impl PlayerImpl of PlayerTrait {
     fn exit(ref self: Player, ref game: Game, out: bool) {
         let (is_locked, id) = self.locked;
         assert(is_locked, 'CANNOT EXIT, PLAYER NOT LOCKED');
-        assert(game.current_player_count != 0, 'GAME PLAYER COUNT SUB');
+        assert(game.current_player_count != 0, 'GAME PLAYER COUNT SUB');    // sub overflow guard
         if out {
             // check game id
             assert(id == game.id, 'BAD REQUEST');
             self.out = (game.id, game.reshuffled);
+        } else {
+            self.out = (0, 0);
         }
 
         self.current_bet = 0;
         self.is_dealer = false;
         self.in_round = false;
         self.locked = (false, 0);
-        self.out = (0, 0);
 
         game.current_player_count -= 1;
     }

--- a/poker-texas-hold-em/contract/src/traits/player.cairo
+++ b/poker-texas-hold-em/contract/src/traits/player.cairo
@@ -8,7 +8,7 @@ pub impl PlayerImpl of PlayerTrait {
     fn exit(ref self: Player, ref game: Game, out: bool) {
         let (is_locked, id) = self.locked;
         assert(is_locked, 'CANNOT EXIT, PLAYER NOT LOCKED');
-        assert(game.current_player_count != 0, 'GAME PLAYER COUNT SUB');    // sub overflow guard
+        assert(game.current_player_count != 0, 'GAME PLAYER COUNT SUB'); // sub overflow guard
         if out {
             // check game id
             assert(id == game.id, 'BAD REQUEST');


### PR DESCRIPTION
## Description   
<!-- Provide a brief summary of the changes in this PR. Explain what was modified and why. -->    
This PR implements the `leave_game` and `end_game` external functions. the first function is called by a player and the functions in the `PlayerTrait` are used, as they perform the adequate security checks. The `Game` is further optimized based on the `GameMode` and the ratio of players left in the game.

The `end_game` is a function called by the "owner" of the game, if the game is ownable. A Game usually finishes when all chips of `available_players - 1` have been run out, or all players decide to leave the game. it takes in a bool value for `force` to immediately resolve the game, whether the round was in progress, or not. logic concerning this would be handled accordingly.

## Related Issues   
Closes #115 
Closes #92 

## Changes Made   - [ ] 
New logic were made, and are currently being made, with internal helper functions.   

## How to Test  
<!-- Explain how a reviewer can test these changes. Provide commands, steps, or expected results if applicable. -->   
`sozo test` 
 
## Screenshots (if applicable)  
<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->    
  
## Checklist  
- [x] My code follows the project's coding style.  
- [x] I have tested these changes locally.   
- [x] Documentation has been updated where necessary.  