### PR TITLE
Extract kicker impl

### DIFF
--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -202,4 +202,16 @@ mod tests {
         let _: (Array<Hand>, Array<Card>) =
             extract_kicker(array![], HandRank::HIGH_CARD.into());
     }
+
+    #[test]
+    #[should_panic]
+    fn test_undefined_rank_panics() {
+        let player = contract_address_const::<'PLAYER1'>();
+        let h = mk_hand(player, array![
+            c(2,0), c(3,0), c(4,0), c(5,0), c(6,0),
+        ]);
+        // 0 maps to UNDEFINED → should panic
+        let _: (Array<Hand>, Array<Card>) =
+            extract_kicker(array![h], 0);
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -278,4 +278,21 @@ mod tests {
         assert(winners.at(0).player == @h1.player, 'Wrong winner on different pairs');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
     }
+
+    #[test]
+    fn test_one_pair_tie() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+        let cards = array![
+            c(8,0), c(8,1), c(14,0), c(13,1), c(2,2)
+        ];
+
+        let h1 = mk_hand(p1, cards.clone());
+        let h2 = mk_hand(p2, cards);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        assert(winners.len() == 2, 'Identical pairs should tie');
+        assert(kicker.len()   == 0, 'Tie, no kicker');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -151,4 +151,27 @@ mod tests {
         assert(winners.len() == 2, 'Both hands should tie');
         assert(kicker.len() == 0, 'Tie means no kicker returned');
     }
+
+    #[test]
+    fn test_one_pair_kicker_ordering() {
+        let player1 = contract_address_const::<'PLAYER1'>();
+        let player2 = contract_address_const::<'PLAYER2'>();
+
+        // Both have pair of 9s:
+        // h1 kickers = [A, K, 3]
+        let h1 = mk_hand(player1, array![
+            c(9,0), c(9,1), c(14,0), c(13,1), c(3,2),
+        ]);
+        // h2 kickers = [A, Q, 5] → Q < K, so h1 should win
+        let h2 = mk_hand(player2, array![
+            c(9,2), c(9,3), c(14,1), c(12,0), c(5,1),
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+
+        assert(winners.len() == 1, 'Only one hand should win');
+        assert(winners.at(0).player == @h1.player, 'Wrong hand won the tie');
+        assert(kicker == h1.cards, 'Winner cards must be returned');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -98,6 +98,7 @@ impl U16HandRank of Into<u16, HandRank> {
     }
 }
 
+/// @pope-h
 #[cfg(test)]
 mod tests {
     use super::{Hand, HandRank, Card, ContractAddress, Royals};

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -335,4 +335,23 @@ mod tests {
         assert(winners.at(0).player == @h2.player, 'Wrong winner on two-pair kicker');
         assert(kicker == h2.cards, 'Kicker must be winner cards');
     }
+
+    #[test]
+    fn test_three_of_a_kind_different_three() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+        // p1: three 9s, p2: three 8s
+        let h1 = mk_hand(p1, array![
+            c(9,0), c(9,1), c(9,2), c(5,0), c(4,1)
+        ]);
+        let h2 = mk_hand(p2, array![
+            c(8,0), c(8,1), c(8,2), c(14,0), c(2,1)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::THREE_OF_A_KIND.into());
+        assert(winners.len() == 1, 'Higher three-of-kind wins');
+        assert(winners.at(0).player == @h1.player, 'Wrong winner on three-of-a-kind');
+        assert(kicker == h1.cards, 'Kicker must be winner cards');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -142,11 +142,12 @@ mod tests {
         let player2 = contract_address_const::<'PLAYER2'>();
 
         // both hands identical → tie, no kicker
-        let cards = array![c(14,0), c(10,1), c(8,2), c(4,3), c(2,0)];
+        let cards = array![c(14, 0), c(10, 1), c(8, 2), c(4, 3), c(2, 0)];
         let h1 = mk_hand(player1, cards.clone());
         let h2 = mk_hand(player2, cards);
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
+        );
 
         assert(winners.len() == 2, 'Both hands should tie');
         assert(kicker.len() == 0, 'Tie means no kicker returned');
@@ -159,16 +160,13 @@ mod tests {
 
         // Both have pair of 9s:
         // h1 kickers = [A, K, 3]
-        let h1 = mk_hand(player1, array![
-            c(9,0), c(9,1), c(14,0), c(13,1), c(3,2),
-        ]);
+        let h1 = mk_hand(player1, array![c(9, 0), c(9, 1), c(14, 0), c(13, 1), c(3, 2)]);
         // h2 kickers = [A, Q, 5] → Q < K, so h1 should win
-        let h2 = mk_hand(player2, array![
-            c(9,2), c(9,3), c(14,1), c(12,0), c(5,1),
-        ]);
+        let h2 = mk_hand(player2, array![c(9, 2), c(9, 3), c(14, 1), c(12, 0), c(5, 1)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into(),
+        );
 
         assert(winners.len() == 1, 'Only one hand should win');
         assert(winners.at(0).player == @h1.player, 'Wrong hand won the tie');
@@ -181,15 +179,12 @@ mod tests {
         let player2 = contract_address_const::<'PLAYER2'>();
 
         // h1: 10-J-Q-K-A, h2: 9-10-J-Q-K
-        let h1 = mk_hand(player1, array![
-            c(10,0), c(11,0), c(12,0), c(13,0), c(14,0),
-        ]);
-        let h2 = mk_hand(player2, array![
-            c(9,1), c(10,1), c(11,1), c(12,1), c(13,1),
-        ]);
+        let h1 = mk_hand(player1, array![c(10, 0), c(11, 0), c(12, 0), c(13, 0), c(14, 0)]);
+        let h2 = mk_hand(player2, array![c(9, 1), c(10, 1), c(11, 1), c(12, 1), c(13, 1)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::STRAIGHT.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::STRAIGHT.into(),
+        );
 
         assert(winners.len() == 2, 'All straights should tie');
         assert(kicker.len() == 0, 'Straights tie, no kicker');
@@ -199,20 +194,16 @@ mod tests {
     #[should_panic]
     fn test_empty_hands_panics() {
         // empty input should hit the first assert and panic
-        let _: (Array<Hand>, Array<Card>) =
-            extract_kicker(array![], HandRank::HIGH_CARD.into());
+        let _: (Array<Hand>, Array<Card>) = extract_kicker(array![], HandRank::HIGH_CARD.into());
     }
 
     #[test]
     #[should_panic]
     fn test_undefined_rank_panics() {
         let player = contract_address_const::<'PLAYER1'>();
-        let h = mk_hand(player, array![
-            c(2,0), c(3,0), c(4,0), c(5,0), c(6,0),
-        ]);
+        let h = mk_hand(player, array![c(2, 0), c(3, 0), c(4, 0), c(5, 0), c(6, 0)]);
         // 0 maps to UNDEFINED → should panic
-        let _: (Array<Hand>, Array<Card>) =
-            extract_kicker(array![h], 0);
+        let _: (Array<Hand>, Array<Card>) = extract_kicker(array![h], 0);
     }
 
     #[test]
@@ -221,16 +212,13 @@ mod tests {
         let p2 = contract_address_const::<'P2'>();
 
         // p1: K♣ Q♦ J♠ 10♣ 9♦  (King high)
-        let h1 = mk_hand(p1, array![
-            c(13, 0), c(12, 1), c(11, 2), c(10, 0), c(9,  1)
-        ]);
+        let h1 = mk_hand(p1, array![c(13, 0), c(12, 1), c(11, 2), c(10, 0), c(9, 1)]);
         // p2: A♥ 5♣ 4♦ 3♠ 2♣   (Ace high)
-        let h2 = mk_hand(p2, array![
-            c(14, 3), c(5,  0), c(4,  1), c(3,  2), c(2,  0)
-        ]);
+        let h2 = mk_hand(p2, array![c(14, 3), c(5, 0), c(4, 1), c(3, 2), c(2, 0)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
+        );
         assert(winners.len() == 1, 'Expected one winner');
         assert(winners.at(0).player == @h2.player, 'Ace-high should win');
         assert(kicker == h2.cards, 'Kicker must be winner cards');
@@ -243,16 +231,13 @@ mod tests {
 
         // both Ace high…
         // p1 second-highest = Q
-        let h1 = mk_hand(p1, array![
-            c(14, 0), c(12, 1), c(10, 2), c(8,  0), c(6,  1)
-        ]);
+        let h1 = mk_hand(p1, array![c(14, 0), c(12, 1), c(10, 2), c(8, 0), c(6, 1)]);
         // p2 second-highest = K
-        let h2 = mk_hand(p2, array![
-            c(14, 3), c(13, 1), c(9,  0), c(7,  2), c(5,  3)
-        ]);
+        let h2 = mk_hand(p2, array![c(14, 3), c(13, 1), c(9, 0), c(7, 2), c(5, 3)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
+        );
         assert(winners.len() == 1, 'Expected one winner');
         assert(winners.at(0).player == @h2.player, 'Higher second-card should win');
         assert(kicker == h2.cards, 'Kicker must be winner cards');
@@ -264,16 +249,13 @@ mod tests {
         let p2 = contract_address_const::<'P2'>();
 
         // p1: pair of Jacks
-        let h1 = mk_hand(p1, array![
-            c(11,0), c(11,1), c(9,0), c(8,1), c(7,2)
-        ]);
+        let h1 = mk_hand(p1, array![c(11, 0), c(11, 1), c(9, 0), c(8, 1), c(7, 2)]);
         // p2: pair of Tens
-        let h2 = mk_hand(p2, array![
-            c(10,2), c(10,3), c(14,0), c(2,1), c(3,2)
-        ]);
+        let h2 = mk_hand(p2, array![c(10, 2), c(10, 3), c(14, 0), c(2, 1), c(3, 2)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into(),
+        );
         assert(winners.len() == 1, 'Higher pair wins');
         assert(winners.at(0).player == @h1.player, 'Wrong winner on different pairs');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
@@ -283,17 +265,16 @@ mod tests {
     fn test_one_pair_tie() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
-        let cards = array![
-            c(8,0), c(8,1), c(14,0), c(13,1), c(2,2)
-        ];
+        let cards = array![c(8, 0), c(8, 1), c(14, 0), c(13, 1), c(2, 2)];
 
         let h1 = mk_hand(p1, cards.clone());
         let h2 = mk_hand(p2, cards);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into(),
+        );
         assert(winners.len() == 2, 'Identical pairs should tie');
-        assert(kicker.len()   == 0, 'Tie, no kicker');
+        assert(kicker.len() == 0, 'Tie, no kicker');
     }
 
     #[test]
@@ -301,16 +282,13 @@ mod tests {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
         // p1: K-K & 2-2
-        let h1 = mk_hand(p1, array![
-            c(13,0), c(13,1), c(2,0), c(2,1), c(9,2)
-        ]);
+        let h1 = mk_hand(p1, array![c(13, 0), c(13, 1), c(2, 0), c(2, 1), c(9, 2)]);
         // p2: Q-Q & J-J
-        let h2 = mk_hand(p2, array![
-            c(12,2), c(12,3), c(11,0), c(11,1), c(8,2)
-        ]);
+        let h2 = mk_hand(p2, array![c(12, 2), c(12, 3), c(11, 0), c(11, 1), c(8, 2)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into(),
+        );
         assert(winners.len() == 1, 'Higher top pair wins');
         assert(winners.at(0).player == @h1.player, 'Wrong winner on two-pair');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
@@ -322,15 +300,12 @@ mod tests {
         let p2 = contract_address_const::<'P2'>();
         // both K-K & Q-Q…
         // p1 kicker = 10, p2 kicker = J
-        let h1 = mk_hand(p1, array![
-            c(13,0), c(13,1), c(12,0), c(12,1), c(10,2)
-        ]);
-        let h2 = mk_hand(p2, array![
-            c(13,2), c(13,3), c(12,2), c(12,3), c(11,0)
-        ]);
+        let h1 = mk_hand(p1, array![c(13, 0), c(13, 1), c(12, 0), c(12, 1), c(10, 2)]);
+        let h2 = mk_hand(p2, array![c(13, 2), c(13, 3), c(12, 2), c(12, 3), c(11, 0)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into(),
+        );
         assert(winners.len() == 1, 'Higher kicker wins');
         assert(winners.at(0).player == @h2.player, 'Wrong winner on two-pair kicker');
         assert(kicker == h2.cards, 'Kicker must be winner cards');
@@ -341,15 +316,12 @@ mod tests {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
         // p1: three 9s, p2: three 8s
-        let h1 = mk_hand(p1, array![
-            c(9,0), c(9,1), c(9,2), c(5,0), c(4,1)
-        ]);
-        let h2 = mk_hand(p2, array![
-            c(8,0), c(8,1), c(8,2), c(14,0), c(2,1)
-        ]);
+        let h1 = mk_hand(p1, array![c(9, 0), c(9, 1), c(9, 2), c(5, 0), c(4, 1)]);
+        let h2 = mk_hand(p2, array![c(8, 0), c(8, 1), c(8, 2), c(14, 0), c(2, 1)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::THREE_OF_A_KIND.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::THREE_OF_A_KIND.into(),
+        );
         assert(winners.len() == 1, 'Higher three-of-kind wins');
         assert(winners.at(0).player == @h1.player, 'Wrong winner on three-of-a-kind');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
@@ -360,16 +332,13 @@ mod tests {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
         // p1 flush hearts: A,J,9,7,3 → Ace highest
-        let h1 = mk_hand(p1, array![
-            c(14,1), c(11,1), c(9,1), c(7,1), c(3,1)
-        ]);
+        let h1 = mk_hand(p1, array![c(14, 1), c(11, 1), c(9, 1), c(7, 1), c(3, 1)]);
         // p2 flush clubs: K,Q,10,8,2 → King highest
-        let h2 = mk_hand(p2, array![
-            c(13,2), c(12,2), c(10,2), c(8,2), c(2,2)
-        ]);
+        let h2 = mk_hand(p2, array![c(13, 2), c(12, 2), c(10, 2), c(8, 2), c(2, 2)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::FLUSH.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::FLUSH.into(),
+        );
         assert(winners.len() == 1, 'Higher flush wins');
         assert(winners.at(0).player == @h1.player, 'Wrong winner on flush');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
@@ -380,15 +349,12 @@ mod tests {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
         // p1: 3×A + 2×K, p2: 3×K + 2×Q
-        let h1 = mk_hand(p1, array![
-            c(14,0), c(14,1), c(14,2), c(13,0), c(13,1)
-        ]);
-        let h2 = mk_hand(p2, array![
-            c(13,2), c(13,3), c(13,1), c(12,0), c(12,1)
-        ]);
+        let h1 = mk_hand(p1, array![c(14, 0), c(14, 1), c(14, 2), c(13, 0), c(13, 1)]);
+        let h2 = mk_hand(p2, array![c(13, 2), c(13, 3), c(13, 1), c(12, 0), c(12, 1)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::FULL_HOUSE.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::FULL_HOUSE.into(),
+        );
         assert(winners.len() == 1, 'Higher triple wins');
         assert(winners.at(0).player == @h1.player, 'Wrong winner on full house');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
@@ -399,15 +365,12 @@ mod tests {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
         // p1: four 7s, p2: four 6s
-        let h1 = mk_hand(p1, array![
-            c(7,0), c(7,1), c(7,2), c(7,3), c(14,0)
-        ]);
-        let h2 = mk_hand(p2, array![
-            c(6,0), c(6,1), c(6,2), c(6,3), c(13,0)
-        ]);
+        let h1 = mk_hand(p1, array![c(7, 0), c(7, 1), c(7, 2), c(7, 3), c(14, 0)]);
+        let h2 = mk_hand(p2, array![c(6, 0), c(6, 1), c(6, 2), c(6, 3), c(13, 0)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::FOUR_OF_A_KIND.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::FOUR_OF_A_KIND.into(),
+        );
         assert(winners.len() == 1, 'Higher four-of-a-kind wins');
         assert(winners.at(0).player == @h1.player, 'Wrong winner on four-of-a-kind');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
@@ -417,33 +380,27 @@ mod tests {
     fn test_straight_flush_tie() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
-        let h1 = mk_hand(p1, array![
-            c(5,0), c(6,0), c(7,0), c(8,0), c(9,0)
-        ]);
-        let h2 = mk_hand(p2, array![
-            c(2,1), c(3,1), c(4,1), c(5,1), c(6,1)
-        ]);
+        let h1 = mk_hand(p1, array![c(5, 0), c(6, 0), c(7, 0), c(8, 0), c(9, 0)]);
+        let h2 = mk_hand(p2, array![c(2, 1), c(3, 1), c(4, 1), c(5, 1), c(6, 1)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::STRAIGHT_FLUSH.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::STRAIGHT_FLUSH.into(),
+        );
         assert(winners.len() == 2, 'All straight-flush hands tie');
-        assert(kicker.len()   == 0, 'Tie, no kicker');
+        assert(kicker.len() == 0, 'Tie, no kicker');
     }
 
     #[test]
     fn test_royal_flush_tie() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
-        let h1 = mk_hand(p1, array![
-            c(10,2), c(11,2), c(12,2), c(13,2), c(14,2)
-        ]);
-        let h2 = mk_hand(p2, array![
-            c(10,1), c(11,1), c(12,1), c(13,1), c(14,1)
-        ]);
+        let h1 = mk_hand(p1, array![c(10, 2), c(11, 2), c(12, 2), c(13, 2), c(14, 2)]);
+        let h2 = mk_hand(p2, array![c(10, 1), c(11, 1), c(12, 1), c(13, 1), c(14, 1)]);
 
-        let (winners, kicker) =
-            extract_kicker(array![h1.clone(), h2.clone()], HandRank::ROYAL_FLUSH.into());
+        let (winners, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::ROYAL_FLUSH.into(),
+        );
         assert(winners.len() == 2, 'All royal-flush hands tie');
-        assert(kicker.len()   == 0, 'Tie, no kicker');
+        assert(kicker.len() == 0, 'Tie, no kicker');
     }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -429,4 +429,21 @@ mod tests {
         assert(winners.len() == 2, 'All straight-flush hands tie');
         assert(kicker.len()   == 0, 'Tie, no kicker');
     }
+
+    #[test]
+    fn test_royal_flush_tie() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+        let h1 = mk_hand(p1, array![
+            c(10,2), c(11,2), c(12,2), c(13,2), c(14,2)
+        ]);
+        let h2 = mk_hand(p2, array![
+            c(10,1), c(11,1), c(12,1), c(13,1), c(14,1)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::ROYAL_FLUSH.into());
+        assert(winners.len() == 2, 'All royal-flush hands tie');
+        assert(kicker.len()   == 0, 'Tie, no kicker');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -214,4 +214,25 @@ mod tests {
         let _: (Array<Hand>, Array<Card>) =
             extract_kicker(array![h], 0);
     }
+
+    #[test]
+    fn test_high_card_different_high() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+
+        // p1: K♣ Q♦ J♠ 10♣ 9♦  (King high)
+        let h1 = mk_hand(p1, array![
+            c(13, 0), c(12, 1), c(11, 2), c(10, 0), c(9,  1)
+        ]);
+        // p2: A♥ 5♣ 4♦ 3♠ 2♣   (Ace high)
+        let h2 = mk_hand(p2, array![
+            c(14, 3), c(5,  0), c(4,  1), c(3,  2), c(2,  0)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        assert(winners.len() == 1, 'Expected one winner');
+        assert(winners.at(0).player == @h2.player, 'Ace-high should win');
+        assert(kicker == h2.cards, 'Kicker must be winner cards');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -354,4 +354,24 @@ mod tests {
         assert(winners.at(0).player == @h1.player, 'Wrong winner on three-of-a-kind');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
     }
+
+    #[test]
+    fn test_flush_different_high() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+        // p1 flush hearts: A,J,9,7,3 → Ace highest
+        let h1 = mk_hand(p1, array![
+            c(14,1), c(11,1), c(9,1), c(7,1), c(3,1)
+        ]);
+        // p2 flush clubs: K,Q,10,8,2 → King highest
+        let h2 = mk_hand(p2, array![
+            c(13,2), c(12,2), c(10,2), c(8,2), c(2,2)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::FLUSH.into());
+        assert(winners.len() == 1, 'Higher flush wins');
+        assert(winners.at(0).player == @h1.player, 'Wrong winner on flush');
+        assert(kicker == h1.cards, 'Kicker must be winner cards');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -174,4 +174,24 @@ mod tests {
         assert(winners.at(0).player == @h1.player, 'Wrong hand won the tie');
         assert(kicker == h1.cards, 'Winner cards must be returned');
     }
+
+    #[test]
+    fn test_straight_always_tie() {
+        let player1 = contract_address_const::<'PLAYER1'>();
+        let player2 = contract_address_const::<'PLAYER2'>();
+
+        // h1: 10-J-Q-K-A, h2: 9-10-J-Q-K
+        let h1 = mk_hand(player1, array![
+            c(10,0), c(11,0), c(12,0), c(13,0), c(14,0),
+        ]);
+        let h2 = mk_hand(player2, array![
+            c(9,1), c(10,1), c(11,1), c(12,1), c(13,1),
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::STRAIGHT.into());
+
+        assert(winners.len() == 2, 'All straights should tie');
+        assert(kicker.len() == 0, 'Straights tie, no kicker');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -295,4 +295,24 @@ mod tests {
         assert(winners.len() == 2, 'Identical pairs should tie');
         assert(kicker.len()   == 0, 'Tie, no kicker');
     }
+
+    #[test]
+    fn test_two_pair_different_high_pair() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+        // p1: K-K & 2-2
+        let h1 = mk_hand(p1, array![
+            c(13,0), c(13,1), c(2,0), c(2,1), c(9,2)
+        ]);
+        // p2: Q-Q & J-J
+        let h2 = mk_hand(p2, array![
+            c(12,2), c(12,3), c(11,0), c(11,1), c(8,2)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into());
+        assert(winners.len() == 1, 'Higher top pair wins');
+        assert(winners.at(0).player == @h1.player, 'Wrong winner on two-pair');
+        assert(kicker == h1.cards, 'Kicker must be winner cards');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -257,4 +257,25 @@ mod tests {
         assert(winners.at(0).player == @h2.player, 'Higher second-card should win');
         assert(kicker == h2.cards, 'Kicker must be winner cards');
     }
+
+    #[test]
+    fn test_one_pair_different_pairs() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+
+        // p1: pair of Jacks
+        let h1 = mk_hand(p1, array![
+            c(11,0), c(11,1), c(9,0), c(8,1), c(7,2)
+        ]);
+        // p2: pair of Tens
+        let h2 = mk_hand(p2, array![
+            c(10,2), c(10,3), c(14,0), c(2,1), c(3,2)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        assert(winners.len() == 1, 'Higher pair wins');
+        assert(winners.at(0).player == @h1.player, 'Wrong winner on different pairs');
+        assert(kicker == h1.cards, 'Kicker must be winner cards');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -393,4 +393,23 @@ mod tests {
         assert(winners.at(0).player == @h1.player, 'Wrong winner on full house');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
     }
+
+    #[test]
+    fn test_four_of_a_kind_different_four() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+        // p1: four 7s, p2: four 6s
+        let h1 = mk_hand(p1, array![
+            c(7,0), c(7,1), c(7,2), c(7,3), c(14,0)
+        ]);
+        let h2 = mk_hand(p2, array![
+            c(6,0), c(6,1), c(6,2), c(6,3), c(13,0)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::FOUR_OF_A_KIND.into());
+        assert(winners.len() == 1, 'Higher four-of-a-kind wins');
+        assert(winners.at(0).player == @h1.player, 'Wrong winner on four-of-a-kind');
+        assert(kicker == h1.cards, 'Kicker must be winner cards');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -235,4 +235,26 @@ mod tests {
         assert(winners.at(0).player == @h2.player, 'Ace-high should win');
         assert(kicker == h2.cards, 'Kicker must be winner cards');
     }
+
+    #[test]
+    fn test_high_card_same_high_different_second() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+
+        // both Ace high…
+        // p1 second-highest = Q
+        let h1 = mk_hand(p1, array![
+            c(14, 0), c(12, 1), c(10, 2), c(8,  0), c(6,  1)
+        ]);
+        // p2 second-highest = K
+        let h2 = mk_hand(p2, array![
+            c(14, 3), c(13, 1), c(9,  0), c(7,  2), c(5,  3)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        assert(winners.len() == 1, 'Expected one winner');
+        assert(winners.at(0).player == @h2.player, 'Higher second-card should win');
+        assert(kicker == h2.cards, 'Kicker must be winner cards');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -374,4 +374,23 @@ mod tests {
         assert(winners.at(0).player == @h1.player, 'Wrong winner on flush');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
     }
+
+    #[test]
+    fn test_full_house_different_three() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+        // p1: 3×A + 2×K, p2: 3×K + 2×Q
+        let h1 = mk_hand(p1, array![
+            c(14,0), c(14,1), c(14,2), c(13,0), c(13,1)
+        ]);
+        let h2 = mk_hand(p2, array![
+            c(13,2), c(13,3), c(13,1), c(12,0), c(12,1)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::FULL_HOUSE.into());
+        assert(winners.len() == 1, 'Higher triple wins');
+        assert(winners.at(0).player == @h1.player, 'Wrong winner on full house');
+        assert(kicker == h1.cards, 'Kicker must be winner cards');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -412,4 +412,21 @@ mod tests {
         assert(winners.at(0).player == @h1.player, 'Wrong winner on four-of-a-kind');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
     }
+
+    #[test]
+    fn test_straight_flush_tie() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+        let h1 = mk_hand(p1, array![
+            c(5,0), c(6,0), c(7,0), c(8,0), c(9,0)
+        ]);
+        let h2 = mk_hand(p2, array![
+            c(2,1), c(3,1), c(4,1), c(5,1), c(6,1)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::STRAIGHT_FLUSH.into());
+        assert(winners.len() == 2, 'All straight-flush hands tie');
+        assert(kicker.len()   == 0, 'Tie, no kicker');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -315,4 +315,24 @@ mod tests {
         assert(winners.at(0).player == @h1.player, 'Wrong winner on two-pair');
         assert(kicker == h1.cards, 'Kicker must be winner cards');
     }
+
+    #[test]
+    fn test_two_pair_same_pairs_different_kicker() {
+        let p1 = contract_address_const::<'P1'>();
+        let p2 = contract_address_const::<'P2'>();
+        // both K-K & Q-Q…
+        // p1 kicker = 10, p2 kicker = J
+        let h1 = mk_hand(p1, array![
+            c(13,0), c(13,1), c(12,0), c(12,1), c(10,2)
+        ]);
+        let h2 = mk_hand(p2, array![
+            c(13,2), c(13,3), c(12,2), c(12,3), c(11,0)
+        ]);
+
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into());
+        assert(winners.len() == 1, 'Higher kicker wins');
+        assert(winners.at(0).player == @h2.player, 'Wrong winner on two-pair kicker');
+        assert(kicker == h2.cards, 'Kicker must be winner cards');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -1,6 +1,7 @@
 use starknet::ContractAddress;
-use super::card::Card;
+use super::card::{Card, Royals};
 use poker::traits::handtrait::HandTrait;
+use poker::utils::hand::evaluate_cards;
 
 /// Created once and for all for every available player.
 #[derive(Serde, Drop, Clone, Debug, PartialEq)]
@@ -94,5 +95,44 @@ impl U16HandRank of Into<u16, HandRank> {
             10 => HandRank::ROYAL_FLUSH,
             _ => HandRank::UNDEFINED,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Hand, HandRank, Card, ContractAddress, Royals};
+    use starknet::contract_address_const;
+    use poker::utils::hand::{extract_kicker};
+    // use crate::models::card::Suits;
+
+    // convenience constructor for cards
+    fn c(value: u16, suit: u8) -> Card {
+        Card { value, suit }
+    }
+
+    // build a 5‐card Hand
+    fn mk_hand(player: ContractAddress, cards: Array<Card>) -> Hand {
+        assert(cards.len() == 5, 'Cards must be exactly 5');
+        Hand { player, cards }
+    }
+
+    #[test]
+    fn test_high_card_single_winner() {
+        let player1 = contract_address_const::<'PLAYER1'>();
+        let player2 = contract_address_const::<'PLAYER2'>();
+
+        // h1: A♠,K♠,Q♠,J♠,10♠  (ace high)
+        let card1 = array![c(14, 0), c(13, 0), c(12, 0), c(11, 0), c(10, 0)];
+        // h2: K♥,Q♥,J♥,10♥,9♥  (king high)
+        let card2 = array![c(13, 1), c(12, 1), c(11, 1), c(10, 1), c(9, 1)];
+
+        let h1 = mk_hand(player1, card1);
+        let h2 = mk_hand(player2, card2);
+
+        let (winners, kicker) = extract_kicker(array![h1.clone(), h2], HandRank::HIGH_CARD.into());
+        assert(winners.len() == 1, 'There should be only 1 winner');
+        assert(winners.at(0).player == @h1.player, 'Wrong winner');
+        // kicker must be the winner’s full 5 cards
+        assert(kicker == h1.cards, 'kicker must be winner cards');
     }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -135,4 +135,20 @@ mod tests {
         // kicker must be the winner’s full 5 cards
         assert(kicker == h1.cards, 'kicker must be winner cards');
     }
+
+    #[test]
+    fn test_high_card_tie() {
+        let player1 = contract_address_const::<'PLAYER1'>();
+        let player2 = contract_address_const::<'PLAYER2'>();
+
+        // both hands identical → tie, no kicker
+        let cards = array![c(14,0), c(10,1), c(8,2), c(4,3), c(2,0)];
+        let h1 = mk_hand(player1, cards.clone());
+        let h2 = mk_hand(player2, cards);
+        let (winners, kicker) =
+            extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+
+        assert(winners.len() == 2, 'Both hands should tie');
+        assert(kicker.len() == 0, 'Tie means no kicker returned');
+    }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -194,4 +194,12 @@ mod tests {
         assert(winners.len() == 2, 'All straights should tie');
         assert(kicker.len() == 0, 'Straights tie, no kicker');
     }
+
+    #[test]
+    #[should_panic]
+    fn test_empty_hands_panics() {
+        // empty input should hit the first assert and panic
+        let _: (Array<Hand>, Array<Card>) =
+            extract_kicker(array![], HandRank::HIGH_CARD.into());
+    }
 }

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -22,7 +22,7 @@ use crate::models::card::{Card, Royals};
 /// # Panics
 /// Panics if the input `hands` array is empty or if any hand does not have exactly 5 cards.
 //
-// @Birdmannn, @pope-h
+// @pope-h
 fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array<Card>) {
     assert(hands.len() > 0, 'Hands array cannot be empty');
     let rank: HandRank = hand_rank.into();
@@ -32,9 +32,9 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             let first_hand = hands.at(0); // Snapshot: @Hand
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_high_card_key(first_hand);
-            let mut winning_indices: Array<usize> = array![0]; // Track indices of winning hands
-            let mut i: usize = 1;
-            while i < hands.len() {
+            let mut winning_indices: Array<usize> = array![0];
+          
+            for i in 1..hands.len() {
                 let hand = hands.at(i); // Snapshot: @Hand
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
                 let key = get_high_card_key(hand);
@@ -45,13 +45,12 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                 } else if cmp == 0 {
                     winning_indices.append(i);
                 }
-                i += 1;
             };
-            // Construct winning_hands from indices
+
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);
-                winning_hands.append(hands[index].clone()); // Clone Hand from input array
+                winning_hands.append(hands[index].clone());
             };
             if winning_hands.len() == 1 {
                 (winning_hands, winning_hands.at(0).cards.clone())
@@ -64,8 +63,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_one_pair_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-            let mut i: usize = 1;
-            while i < hands.len() {
+          
+            for i in 1..hands.len() {
                 let hand = hands.at(i);
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
                 let key = get_one_pair_key(hand);
@@ -76,8 +75,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                 } else if cmp == 0 {
                     winning_indices.append(i);
                 }
-                i += 1;
             };
+           
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);
@@ -94,8 +93,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_two_pair_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-            let mut i: usize = 1;
-            while i < hands.len() {
+         
+            for i in 1..hands.len() {
                 let hand = hands.at(i);
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
                 let key = get_two_pair_key(hand);
@@ -106,8 +105,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                 } else if cmp == 0 {
                     winning_indices.append(i);
                 }
-                i += 1;
             };
+           
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);
@@ -124,8 +123,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_three_of_a_kind_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-            let mut i: usize = 1;
-            while i < hands.len() {
+          
+            for i in 1..hands.len() {
                 let hand = hands.at(i);
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
                 let key = get_three_of_a_kind_key(hand);
@@ -136,8 +135,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                 } else if cmp == 0 {
                     winning_indices.append(i);
                 }
-                i += 1;
             };
+           
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);
@@ -150,12 +149,10 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             }
         },
         HandRank::STRAIGHT | HandRank::STRAIGHT_FLUSH | HandRank::ROYAL_FLUSH => {
-            let mut i: usize = 0;
-            while i < hands.len() {
+            for i in 0..hands.len() {
                 assert(hands.at(i).cards.len() == 5, 'Hand must have 5 cards');
-                i += 1;
             };
-            // Clone the entire hands array for the result
+            
             let mut result_hands: Array<Hand> = array![];
             for j in 0..hands.len() {
                 result_hands.append(hands[j].clone());
@@ -167,8 +164,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_full_house_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-            let mut i: usize = 1;
-            while i < hands.len() {
+           
+            for i in 1..hands.len() {
                 let hand = hands.at(i);
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
                 let key = get_full_house_key(hand);
@@ -179,8 +176,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                 } else if cmp == 0 {
                     winning_indices.append(i);
                 }
-                i += 1;
             };
+            
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);
@@ -197,8 +194,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_four_of_a_kind_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-            let mut i: usize = 1;
-            while i < hands.len() {
+
+            for i in 1..hands.len() {
                 let hand = hands.at(i);
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
                 let key = get_four_of_a_kind_key(hand);
@@ -209,8 +206,8 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                 } else if cmp == 0 {
                     winning_indices.append(i);
                 }
-                i += 1;
             };
+
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -424,6 +424,24 @@ fn ashura(arr: Array<(u16, u16, u8)>) -> (bool, bool) {
     (is_flush, is_straight_high || is_straight_low)
 }
 
+/// Sorts an array of cards by poker value in descending order (Ace as 14, King as 13, etc.).
+/// @pope-h
+fn sort_cards_by_poker_value(cards: @Array<Card>) -> Array<Card> {
+    let mut card_data: Array<(u16, u16, u8)> = array![];
+    for i in 0..cards.len() {
+        let card = *cards.at(i);
+        let poker_value = if card.value == Royals::ACE { 14_u16 } else { card.value };
+        card_data.append((card.value, poker_value, card.suit));
+    };
+    let sorted_data = bubble_sort(card_data);
+    let mut sorted_cards: Array<Card> = array![];
+    for i in 0..sorted_data.len() {
+        let (value, _, suit) = *sorted_data.at(i);
+        sorted_cards.append(Card { suit, value });
+    };
+    sorted_cards
+}
+
 /// FOR KICKER, SORT ALL CARDS AND COMPARE THEIR FIRST VALUES (POKER_VAL)
 /// THE REST SHOULD BE HISTORY. :)
 ///

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -1,11 +1,231 @@
 use crate::models::hand::{Hand, HandRank};
 use crate::models::card::{Card, Royals};
 
-/// @Birdmannn
-fn extract_kicker(hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array<Card>) {
-    // Implement kicker based on hand_rank
-    // some hand_ranks have a different kicker implementation from the rest
-    (array![], array![])
+/// Determines the winning hand(s) among an array of hands with the same HandRank.
+///
+/// This function compares hands of equal rank using poker tie-breaking rules specific to each
+/// HandRank. It assumes all input hands have the same rank and contain exactly 5 cards.
+/// For ranks like STRAIGHT, STRAIGHT_FLUSH, and ROYAL_FLUSH, where ties are determined solely
+/// by the rank itself, all hands are considered equal if they share the same rank.
+///
+/// # Arguments
+/// * `hands` - An array of Hand structs, each with the same HandRank.
+/// * `hand_rank` - The u16 representation of the HandRank shared by all hands.
+///
+/// # Returns
+/// A tuple containing:
+/// 1. An `Array<Hand>` of the winning hand(s).
+/// 2. An `Array<Card>` of kicker cards:
+///    - If a single hand wins, contains all 5 cards of that hand.
+///    - If multiple hands tie, contains an empty array, indicating no further tie-breaking.
+///
+/// # Panics
+/// Panics if the input `hands` array is empty or if any hand does not have exactly 5 cards.
+//
+// @Birdmannn, @pope-h
+fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array<Card>) {
+    assert(hands.len() > 0, 'Hands array cannot be empty');
+    let rank: HandRank = hand_rank.into();
+
+    match rank {
+        HandRank::HIGH_CARD | HandRank::FLUSH => {
+            let first_hand = hands.at(0); // Snapshot: @Hand
+            assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
+            let mut max_key = get_high_card_key(first_hand);
+            let mut winning_indices: Array<usize> = array![0]; // Track indices of winning hands
+            let mut i: usize = 1;
+            while i < hands.len() {
+                let hand = hands.at(i); // Snapshot: @Hand
+                assert(hand.cards.len() == 5, 'Hand must have 5 cards');
+                let key = get_high_card_key(hand);
+                let cmp = compare_arrays(@key, @max_key);
+                if cmp == 1 {
+                    max_key = key;
+                    winning_indices = array![i];
+                } else if cmp == 0 {
+                    winning_indices.append(i);
+                }
+                i += 1;
+            };
+            // Construct winning_hands from indices
+            let mut winning_hands: Array<Hand> = array![];
+            for j in 0..winning_indices.len() {
+                let index = *winning_indices.at(j);
+                winning_hands.append(hands[index].clone()); // Clone Hand from input array
+            };
+            if winning_hands.len() == 1 {
+                (winning_hands, winning_hands.at(0).cards.clone())
+            } else {
+                (winning_hands, array![])
+            }
+        },
+        HandRank::ONE_PAIR => {
+            let first_hand = hands.at(0);
+            assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
+            let mut max_key = get_one_pair_key(first_hand);
+            let mut winning_indices: Array<usize> = array![0];
+            let mut i: usize = 1;
+            while i < hands.len() {
+                let hand = hands.at(i);
+                assert(hand.cards.len() == 5, 'Hand must have 5 cards');
+                let key = get_one_pair_key(hand);
+                let cmp = compare_arrays(@key, @max_key);
+                if cmp == 1 {
+                    max_key = key;
+                    winning_indices = array![i];
+                } else if cmp == 0 {
+                    winning_indices.append(i);
+                }
+                i += 1;
+            };
+            let mut winning_hands: Array<Hand> = array![];
+            for j in 0..winning_indices.len() {
+                let index = *winning_indices.at(j);
+                winning_hands.append(hands[index].clone());
+            };
+            if winning_hands.len() == 1 {
+                (winning_hands, winning_hands.at(0).cards.clone())
+            } else {
+                (winning_hands, array![])
+            }
+        },
+        HandRank::TWO_PAIR => {
+            let first_hand = hands.at(0);
+            assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
+            let mut max_key = get_two_pair_key(first_hand);
+            let mut winning_indices: Array<usize> = array![0];
+            let mut i: usize = 1;
+            while i < hands.len() {
+                let hand = hands.at(i);
+                assert(hand.cards.len() == 5, 'Hand must have 5 cards');
+                let key = get_two_pair_key(hand);
+                let cmp = compare_arrays(@key, @max_key);
+                if cmp == 1 {
+                    max_key = key;
+                    winning_indices = array![i];
+                } else if cmp == 0 {
+                    winning_indices.append(i);
+                }
+                i += 1;
+            };
+            let mut winning_hands: Array<Hand> = array![];
+            for j in 0..winning_indices.len() {
+                let index = *winning_indices.at(j);
+                winning_hands.append(hands[index].clone());
+            };
+            if winning_hands.len() == 1 {
+                (winning_hands, winning_hands.at(0).cards.clone())
+            } else {
+                (winning_hands, array![])
+            }
+        },
+        HandRank::THREE_OF_A_KIND => {
+            let first_hand = hands.at(0);
+            assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
+            let mut max_key = get_three_of_a_kind_key(first_hand);
+            let mut winning_indices: Array<usize> = array![0];
+            let mut i: usize = 1;
+            while i < hands.len() {
+                let hand = hands.at(i);
+                assert(hand.cards.len() == 5, 'Hand must have 5 cards');
+                let key = get_three_of_a_kind_key(hand);
+                let cmp = compare_arrays(@key, @max_key);
+                if cmp == 1 {
+                    max_key = key;
+                    winning_indices = array![i];
+                } else if cmp == 0 {
+                    winning_indices.append(i);
+                }
+                i += 1;
+            };
+            let mut winning_hands: Array<Hand> = array![];
+            for j in 0..winning_indices.len() {
+                let index = *winning_indices.at(j);
+                winning_hands.append(hands[index].clone());
+            };
+            if winning_hands.len() == 1 {
+                (winning_hands, winning_hands.at(0).cards.clone())
+            } else {
+                (winning_hands, array![])
+            }
+        },
+        HandRank::STRAIGHT | HandRank::STRAIGHT_FLUSH | HandRank::ROYAL_FLUSH => {
+            let mut i: usize = 0;
+            while i < hands.len() {
+                assert(hands.at(i).cards.len() == 5, 'Hand must have 5 cards');
+                i += 1;
+            };
+            // Clone the entire hands array for the result
+            let mut result_hands: Array<Hand> = array![];
+            for j in 0..hands.len() {
+                result_hands.append(hands[j].clone());
+            };
+            (result_hands, array![])
+        },
+        HandRank::FULL_HOUSE => {
+            let first_hand = hands.at(0);
+            assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
+            let mut max_key = get_full_house_key(first_hand);
+            let mut winning_indices: Array<usize> = array![0];
+            let mut i: usize = 1;
+            while i < hands.len() {
+                let hand = hands.at(i);
+                assert(hand.cards.len() == 5, 'Hand must have 5 cards');
+                let key = get_full_house_key(hand);
+                let cmp = compare_arrays(@key, @max_key);
+                if cmp == 1 {
+                    max_key = key;
+                    winning_indices = array![i];
+                } else if cmp == 0 {
+                    winning_indices.append(i);
+                }
+                i += 1;
+            };
+            let mut winning_hands: Array<Hand> = array![];
+            for j in 0..winning_indices.len() {
+                let index = *winning_indices.at(j);
+                winning_hands.append(hands[index].clone());
+            };
+            if winning_hands.len() == 1 {
+                (winning_hands, winning_hands.at(0).cards.clone())
+            } else {
+                (winning_hands, array![])
+            }
+        },
+        HandRank::FOUR_OF_A_KIND => {
+            let first_hand = hands.at(0);
+            assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
+            let mut max_key = get_four_of_a_kind_key(first_hand);
+            let mut winning_indices: Array<usize> = array![0];
+            let mut i: usize = 1;
+            while i < hands.len() {
+                let hand = hands.at(i);
+                assert(hand.cards.len() == 5, 'Hand must have 5 cards');
+                let key = get_four_of_a_kind_key(hand);
+                let cmp = compare_arrays(@key, @max_key);
+                if cmp == 1 {
+                    max_key = key;
+                    winning_indices = array![i];
+                } else if cmp == 0 {
+                    winning_indices.append(i);
+                }
+                i += 1;
+            };
+            let mut winning_hands: Array<Hand> = array![];
+            for j in 0..winning_indices.len() {
+                let index = *winning_indices.at(j);
+                winning_hands.append(hands[index].clone());
+            };
+            if winning_hands.len() == 1 {
+                (winning_hands, winning_hands.at(0).cards.clone())
+            } else {
+                (winning_hands, array![])
+            }
+        },
+        HandRank::UNDEFINED => {
+            panic(array!['Undefined hand rank'])
+        }
+    }
 }
 
 /// @pope-h

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -442,6 +442,23 @@ fn sort_cards_by_poker_value(cards: @Array<Card>) -> Array<Card> {
     sorted_cards
 }
 
+/// Sorts an array of u16 values in descending order.
+fn bubble_sort_u16(mut arr: Array<u16>) -> Array<u16> {
+    let mut swapped = true;
+    while swapped {
+        swapped = false;
+        for i in 0..arr.len() - 1 {
+            if *arr.at(i) < *arr.at(i + 1) {
+                let temp = *arr.at(i);
+                arr = set_array_element(arr.clone(), i, *arr.at(i + 1));
+                arr = set_array_element(arr, i + 1, temp);
+                swapped = true;
+            };
+        };
+    };
+    arr
+}
+
 /// FOR KICKER, SORT ALL CARDS AND COMPARE THEIR FIRST VALUES (POKER_VAL)
 /// THE REST SHOULD BE HISTORY. :)
 ///

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -28,12 +28,13 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
     let rank: HandRank = hand_rank.into();
 
     match rank {
-        HandRank::HIGH_CARD | HandRank::FLUSH => {
+        HandRank::HIGH_CARD |
+        HandRank::FLUSH => {
             let first_hand = hands.at(0); // Snapshot: @Hand
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_high_card_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-          
+
             for i in 1..hands.len() {
                 let hand = hands.at(i); // Snapshot: @Hand
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
@@ -63,7 +64,7 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_one_pair_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-          
+
             for i in 1..hands.len() {
                 let hand = hands.at(i);
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
@@ -76,7 +77,7 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                     winning_indices.append(i);
                 }
             };
-           
+
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);
@@ -93,7 +94,7 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_two_pair_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-         
+
             for i in 1..hands.len() {
                 let hand = hands.at(i);
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
@@ -106,7 +107,7 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                     winning_indices.append(i);
                 }
             };
-           
+
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);
@@ -123,7 +124,7 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_three_of_a_kind_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-          
+
             for i in 1..hands.len() {
                 let hand = hands.at(i);
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
@@ -136,7 +137,7 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                     winning_indices.append(i);
                 }
             };
-           
+
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);
@@ -148,11 +149,12 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                 (winning_hands, array![])
             }
         },
-        HandRank::STRAIGHT | HandRank::STRAIGHT_FLUSH | HandRank::ROYAL_FLUSH => {
+        HandRank::STRAIGHT | HandRank::STRAIGHT_FLUSH |
+        HandRank::ROYAL_FLUSH => {
             for i in 0..hands.len() {
                 assert(hands.at(i).cards.len() == 5, 'Hand must have 5 cards');
             };
-            
+
             let mut result_hands: Array<Hand> = array![];
             for j in 0..hands.len() {
                 result_hands.append(hands[j].clone());
@@ -164,7 +166,7 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             assert(first_hand.cards.len() == 5, 'Hand must have 5 cards');
             let mut max_key = get_full_house_key(first_hand);
             let mut winning_indices: Array<usize> = array![0];
-           
+
             for i in 1..hands.len() {
                 let hand = hands.at(i);
                 assert(hand.cards.len() == 5, 'Hand must have 5 cards');
@@ -177,7 +179,7 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                     winning_indices.append(i);
                 }
             };
-            
+
             let mut winning_hands: Array<Hand> = array![];
             for j in 0..winning_indices.len() {
                 let index = *winning_indices.at(j);
@@ -219,9 +221,7 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
                 (winning_hands, array![])
             }
         },
-        HandRank::UNDEFINED => {
-            panic(array!['Undefined hand rank'])
-        }
+        HandRank::UNDEFINED => { panic(array!['Undefined hand rank']) },
     }
 }
 
@@ -427,7 +427,11 @@ fn sort_cards_by_poker_value(cards: @Array<Card>) -> Array<Card> {
     let mut card_data: Array<(u16, u16, u8)> = array![];
     for i in 0..cards.len() {
         let card = *cards.at(i);
-        let poker_value = if card.value == Royals::ACE { 14_u16 } else { card.value };
+        let poker_value = if card.value == Royals::ACE {
+            14_u16
+        } else {
+            card.value
+        };
         card_data.append((card.value, poker_value, card.suit));
     };
     let sorted_data = bubble_sort(card_data);
@@ -572,7 +576,11 @@ fn get_high_card_key(hand: @Hand) -> Array<u16> {
     let mut values: Array<u16> = array![];
     for i in 0..sorted_cards.len() {
         let card = *sorted_cards.at(i);
-        let poker_value = if card.value == Royals::ACE { 14_u16 } else { card.value };
+        let poker_value = if card.value == Royals::ACE {
+            14_u16
+        } else {
+            card.value
+        };
         values.append(poker_value);
     };
     values
@@ -582,7 +590,11 @@ fn get_high_card_key(hand: @Hand) -> Array<u16> {
 fn compare_arrays(a: @Array<u16>, b: @Array<u16>) -> felt252 {
     let len_a = a.len();
     let len_b = b.len();
-    let min_len = if len_a < len_b { len_a } else { len_b };
+    let min_len = if len_a < len_b {
+        len_a
+    } else {
+        len_b
+    };
     let mut result: felt252 = 0;
 
     for i in 0..min_len {

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -526,6 +526,27 @@ fn get_three_of_a_kind_key(hand: @Hand) -> Array<u16> {
     array![three_value, *sorted_kickers.at(0), *sorted_kickers.at(1)]
 }
 
+/// Extracts the comparison key for FULL_HOUSE: (three_value, pair_value).
+/// @pope-h
+fn get_full_house_key(hand: @Hand) -> Array<u16> {
+    let mut value_counts: Felt252Dict<u8> = Default::default();
+    for i in 0..hand.cards.len() {
+        let card = *hand.cards.at(i);
+        value_counts.insert(card.value.into(), value_counts.get(card.value.into()) + 1);
+    };
+    let mut three_value: u16 = 0;
+    let mut pair_value: u16 = 0;
+    for v in 1..15_u16 {
+        let count = value_counts.get(v.into());
+        if count == 3 {
+            three_value = v;
+        } else if count == 2 {
+            pair_value = v;
+        }
+    };
+    array![three_value, pair_value]
+}
+
 /// FOR KICKER, SORT ALL CARDS AND COMPARE THEIR FIRST VALUES (POKER_VAL)
 /// THE REST SHOULD BE HISTORY. :)
 ///

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -568,6 +568,19 @@ fn get_four_of_a_kind_key(hand: @Hand) -> Array<u16> {
     array![four_value, kicker]
 }
 
+/// Extracts the comparison key for HIGH_CARD or FLUSH: (val1, val2, val3, val4, val5).
+/// @pope-h
+fn get_high_card_key(hand: @Hand) -> Array<u16> {
+    let sorted_cards = sort_cards_by_poker_value(hand.cards);
+    let mut values: Array<u16> = array![];
+    for i in 0..sorted_cards.len() {
+        let card = *sorted_cards.at(i);
+        let poker_value = if card.value == Royals::ACE { 14_u16 } else { card.value };
+        values.append(poker_value);
+    };
+    values
+}
+
 /// FOR KICKER, SORT ALL CARDS AND COMPARE THEIR FIRST VALUES (POKER_VAL)
 /// THE REST SHOULD BE HISTORY. :)
 ///

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -581,6 +581,39 @@ fn get_high_card_key(hand: @Hand) -> Array<u16> {
     values
 }
 
+/// @pope-h
+fn compare_arrays(a: @Array<u16>, b: @Array<u16>) -> felt252 {
+    let len_a = a.len();
+    let len_b = b.len();
+    let min_len = if len_a < len_b { len_a } else { len_b };
+    let mut result: felt252 = 0;
+
+    for i in 0..min_len {
+        if result != 0 {
+            break;
+        }
+        let val_a = *a.at(i);
+        let val_b = *b.at(i);
+        if val_a > val_b {
+            result = 1;
+            break;
+        } else if val_a < val_b {
+            result = -1;
+            break;
+        }
+    };
+
+    if result != 0 {
+        result
+    } else if len_a > len_b {
+        1
+    } else if len_a < len_b {
+        -1
+    } else {
+        0
+    }
+}
+
 /// FOR KICKER, SORT ALL CARDS AND COMPARE THEIR FIRST VALUES (POKER_VAL)
 /// THE REST SHOULD BE HISTORY. :)
 ///

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -504,6 +504,28 @@ fn get_two_pair_key(hand: @Hand) -> Array<u16> {
     array![*sorted_pairs.at(0), *sorted_pairs.at(1), kicker]
 }
 
+/// Extracts the comparison key for THREE_OF_A_KIND: (three_value, kicker1, kicker2).
+/// @pope-h
+fn get_three_of_a_kind_key(hand: @Hand) -> Array<u16> {
+    let mut value_counts: Felt252Dict<u8> = Default::default();
+    for i in 0..hand.cards.len() {
+        let card = *hand.cards.at(i);
+        value_counts.insert(card.value.into(), value_counts.get(card.value.into()) + 1);
+    };
+    let mut three_value: u16 = 0;
+    let mut kickers: Array<u16> = array![];
+    for v in 1..15_u16 {
+        let count = value_counts.get(v.into());
+        if count == 3 {
+            three_value = v;
+        } else if count == 1 {
+            kickers.append(v);
+        }
+    };
+    let sorted_kickers = bubble_sort_u16(kickers);
+    array![three_value, *sorted_kickers.at(0), *sorted_kickers.at(1)]
+}
+
 /// FOR KICKER, SORT ALL CARDS AND COMPARE THEIR FIRST VALUES (POKER_VAL)
 /// THE REST SHOULD BE HISTORY. :)
 ///

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -482,6 +482,28 @@ fn get_one_pair_key(hand: @Hand) -> Array<u16> {
     array![pair_value, *sorted_kickers.at(0), *sorted_kickers.at(1), *sorted_kickers.at(2)]
 }
 
+/// Extracts the comparison key for TWO_PAIR: (high_pair, low_pair, kicker).
+/// @pope-h
+fn get_two_pair_key(hand: @Hand) -> Array<u16> {
+    let mut value_counts: Felt252Dict<u8> = Default::default();
+    for i in 0..hand.cards.len() {
+        let card = *hand.cards.at(i);
+        value_counts.insert(card.value.into(), value_counts.get(card.value.into()) + 1);
+    };
+    let mut pairs: Array<u16> = array![];
+    let mut kicker: u16 = 0;
+    for v in 1..15_u16 {
+        let count = value_counts.get(v.into());
+        if count == 2 {
+            pairs.append(v);
+        } else if count == 1 {
+            kicker = v;
+        }
+    };
+    let sorted_pairs = bubble_sort_u16(pairs);
+    array![*sorted_pairs.at(0), *sorted_pairs.at(1), kicker]
+}
+
 /// FOR KICKER, SORT ALL CARDS AND COMPARE THEIR FIRST VALUES (POKER_VAL)
 /// THE REST SHOULD BE HISTORY. :)
 ///

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -547,6 +547,27 @@ fn get_full_house_key(hand: @Hand) -> Array<u16> {
     array![three_value, pair_value]
 }
 
+/// Extracts the comparison key for FOUR_OF_A_KIND: (four_value, kicker).
+/// @pope-h
+fn get_four_of_a_kind_key(hand: @Hand) -> Array<u16> {
+    let mut value_counts: Felt252Dict<u8> = Default::default();
+    for i in 0..hand.cards.len() {
+        let card = *hand.cards.at(i);
+        value_counts.insert(card.value.into(), value_counts.get(card.value.into()) + 1);
+    };
+    let mut four_value: u16 = 0;
+    let mut kicker: u16 = 0;
+    for v in 1..15_u16 {
+        let count = value_counts.get(v.into());
+        if count == 4 {
+            four_value = v;
+        } else if count == 1 {
+            kicker = v;
+        }
+    };
+    array![four_value, kicker]
+}
+
 /// FOR KICKER, SORT ALL CARDS AND COMPARE THEIR FIRST VALUES (POKER_VAL)
 /// THE REST SHOULD BE HISTORY. :)
 ///

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -443,6 +443,7 @@ fn sort_cards_by_poker_value(cards: @Array<Card>) -> Array<Card> {
 }
 
 /// Sorts an array of u16 values in descending order.
+/// @pope-h
 fn bubble_sort_u16(mut arr: Array<u16>) -> Array<u16> {
     let mut swapped = true;
     while swapped {
@@ -457,6 +458,28 @@ fn bubble_sort_u16(mut arr: Array<u16>) -> Array<u16> {
         };
     };
     arr
+}
+
+/// Extracts the comparison key for ONE_PAIR: (pair_value, kicker1, kicker2, kicker3).
+/// @pope-h
+fn get_one_pair_key(hand: @Hand) -> Array<u16> {
+    let mut value_counts: Felt252Dict<u8> = Default::default();
+    for i in 0..hand.cards.len() {
+        let card = *hand.cards.at(i);
+        value_counts.insert(card.value.into(), value_counts.get(card.value.into()) + 1);
+    };
+    let mut pair_value: u16 = 0;
+    let mut kickers: Array<u16> = array![];
+    for v in 1..15_u16 {
+        let count = value_counts.get(v.into());
+        if count == 2 {
+            pair_value = v;
+        } else if count == 1 {
+            kickers.append(v);
+        }
+    };
+    let sorted_kickers = bubble_sort_u16(kickers);
+    array![pair_value, *sorted_kickers.at(0), *sorted_kickers.at(1), *sorted_kickers.at(2)]
 }
 
 /// FOR KICKER, SORT ALL CARDS AND COMPARE THEIR FIRST VALUES (POKER_VAL)


### PR DESCRIPTION
## Description   
Implemented the extract_kicker function and all accompanying tie-breaker key generators to fully support poker hand comparison and kicker extraction across every HandRank. Added helper utilities for sorting, combination generation, and value counting to enable correct tie-breaking for HIGH_CARD, ONE_PAIR, TWO_PAIR, THREE_OF_A_KIND, FULL_HOUSE, FOUR_OF_A_KIND, FLUSH, and handled STRAIGHT-type ranks as automatic ties. Also cleaned up documentation comments and ensured all new code is covered by unit tests.    

## Related Issues   
<!-- No existing issues linked; this PR adds core hand-evaluation logic. -->    

## Changes Made   - [ ] 
- Added extract_kicker implementation covering all HandRank variants

- Created get_high_card_key, get_one_pair_key, get_two_pair_key, get_three_of_a_kind_key, get_full_house_key, get_four_of_a_kind_key for rank-specific tie-breaker keys

- Implemented compare_arrays to lexicographically compare key arrays

- Added sort_cards_by_poker_value, bubble_sort (for (u16,u16,u8)), bubble_sort_u16, and bubble_sort_u8 for descending ordering

- Added generate_combinations utility for future hand-generation needs

- Updated evaluate_cards to delegate to the new kicker logic and maintain existing rank-determination behavior

- Wrote extensive unit tests covering all edge cases in tests module 

## How to Test  
Navigate to the contract folder and run `sozo test`   
 
## Screenshots (if applicable)  
<!-- No UI changes in this PR. -->    
  
## Checklist  
- [X] My code follows the project's coding style.  
- [X] I have tested these changes locally.   
- [X] Documentation has been updated where necessary.  