### PR TITLE
Feat: Implement Start Round Function

### DIFF
--- a/poker-texas-hold-em/contract/Scarb.lock
+++ b/poker-texas-hold-em/contract/Scarb.lock
@@ -3,8 +3,8 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "1.1.0"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.1.0#dd7e42d92ecd5cf59354a34c5dbe6f9d6e20ed0e"
+version = "1.2.0"
+source = "git+https://github.com/dojoengine/dojo?tag=v1.2.0#596f96d2af81ef3327bcdb7a78c323b88fe12b82"
 dependencies = [
  "dojo_plugin",
 ]
@@ -12,7 +12,7 @@ dependencies = [
 [[package]]
 name = "dojo_cairo_test"
 version = "1.0.12"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.1.0#dd7e42d92ecd5cf59354a34c5dbe6f9d6e20ed0e"
+source = "git+https://github.com/dojoengine/dojo?tag=v1.2.0#596f96d2af81ef3327bcdb7a78c323b88fe12b82"
 dependencies = [
  "dojo",
 ]
@@ -20,7 +20,7 @@ dependencies = [
 [[package]]
 name = "dojo_plugin"
 version = "2.9.2"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.1.0#dd7e42d92ecd5cf59354a34c5dbe6f9d6e20ed0e"
+source = "git+https://github.com/dojoengine/dojo?tag=v1.2.0#596f96d2af81ef3327bcdb7a78c323b88fe12b82"
 
 [[package]]
 name = "poker"

--- a/poker-texas-hold-em/contract/Scarb.toml
+++ b/poker-texas-hold-em/contract/Scarb.toml
@@ -12,11 +12,11 @@ spawn = "sozo execute dojo_starter-actions spawn --wait"    # scarb run spawn
 move = "sozo execute dojo_starter-actions move -c 1 --wait" # scarb run move
 
 [dependencies]
-dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.1.0" }
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.2.0" }
 
 [[target.starknet-contract]]
 build-external-contracts = ["dojo::world::world_contract::world"]
 
 [dev-dependencies]
 cairo_test = "=2.9.2"
-dojo_cairo_test = { git = "https://github.com/dojoengine/dojo", tag = "v1.1.0" }
+dojo_cairo_test = { git = "https://github.com/dojoengine/dojo", tag = "v1.2.0" }

--- a/poker-texas-hold-em/contract/src/models/base.cairo
+++ b/poker-texas-hold-em/contract/src/models/base.cairo
@@ -94,7 +94,6 @@ pub struct RoundStarted {
     pub dealer: ContractAddress,
     pub current_game_bet: u256,
     pub small_blind_player: ContractAddress,
-    pub big_blind_player: ContractAddress,
     pub next_player: ContractAddress,
     pub no_of_players: u32,
 }

--- a/poker-texas-hold-em/contract/src/models/base.cairo
+++ b/poker-texas-hold-em/contract/src/models/base.cairo
@@ -63,6 +63,20 @@ pub struct PlayerJoined {
     pub expected_no_of_players: u32,
 }
 
+#[derive(Drop, Serde)]
+#[dojo::event]
+pub struct RoundStarted {
+    #[key]
+    pub game_id: u64,
+    #[key]
+    pub dealer: ContractAddress,
+    pub current_game_bet: u256,
+    pub small_blind_player: ContractAddress,
+    pub big_blind_player: ContractAddress,
+    pub next_player: ContractAddress,
+    pub expected_no_of_players: u32,
+}
+
 /// MODEL
 
 #[derive(Serde, Copy, Drop, PartialEq)]

--- a/poker-texas-hold-em/contract/src/models/base.cairo
+++ b/poker-texas-hold-em/contract/src/models/base.cairo
@@ -74,7 +74,7 @@ pub struct RoundStarted {
     pub small_blind_player: ContractAddress,
     pub big_blind_player: ContractAddress,
     pub next_player: ContractAddress,
-    pub expected_no_of_players: u32,
+    pub no_of_players: u32,
 }
 
 /// MODEL

--- a/poker-texas-hold-em/contract/src/models/player.cairo
+++ b/poker-texas-hold-em/contract/src/models/player.cairo
@@ -10,7 +10,7 @@ use poker::traits::player::PlayerTrait;
 
 // FOR NOW, NO PLAYER CAN HAVE MORE THAN ONE HAND.
 // Go to all functions that use player as a parameter, and remove the snapshot
-#[derive(Drop, Serde, Debug, Hash)]
+#[derive(Copy, Drop, Serde, Debug, PartialEq, Hash)]
 #[dojo::model]
 pub struct Player {
     #[key]

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -6,7 +6,7 @@ pub mod actions {
     use dojo::event::EventStorage;
     use poker::models::base::{
         GameErrors, Id, GameInitialized, CardDealt, HandCreated, HandResolved, RoundResolved,
-        PlayerJoined,
+        PlayerJoined, RoundStarted
     };
     use poker::models::card::{Card, CardTrait};
     use poker::models::deck::{Deck, DeckTrait};
@@ -622,6 +622,107 @@ pub mod actions {
             world.write_model(@game);
 
             game.community_cards
+        }
+
+        // @OWK50GA
+        // STEP 1:
+            // Change dealer/select dealer: this is because each round has a new dealer. Remember the dealer
+            //  choosing algorithm used in this project
+
+            // STEP 2:
+            // Initialize pots to take small blind and big blind. The small blind guy is the one immediately next 
+            // to the dealer (left hand), while the big blind guy is next to the small blind guy
+
+            // STEP 3:
+            // Reset all previous round game variables, including bets and player amounts. Clear round actions as well
+            // so that you can record other actions. Also update the current_bet (minimum players must call to stay in)
+
+            // STEP 4:
+            // Shuffle, and then deal hole cards. The function is in this contract already
+
+            // STEP 5:
+            // Set player turn, to the player immediately right of the big blind, so that the engine knows whose turn it is.
+
+            // STEP 6:
+            // Initialize community cards placeholder, and betting counter
+        fn _start_round(ref self: ContractState, game_id: u64, ref players: Array<Player>) {
+            // Load world and game
+            let mut world = self.world_default();
+            let mut game: Game = world.read_model(game_id);
+
+            let next_dealer_opt: Option<Player> = self._get_dealer(players.at(0));
+            assert(next_dealer_opt.is_some(), 'Dealer not found');
+            let next_dealer = next_dealer_opt.unwrap();
+            world.write_model(@next_dealer);
+
+            // Get dealer index, so that you can assign blinds
+            let mut dealer_index = 0;
+            let total_players = players.len();
+            let mut i = 0;
+            while i < total_players {
+                let current_player = players.at(i);
+                if *current_player == next_dealer {
+                    dealer_index = i;
+                    break;
+                }
+                i += 1;
+            };
+
+            // Post blinds now you have dealer index. Player to the left for small blind, right for big blind.
+            // We are taking 0 to length as left to right, so dealer_index - 1 for small blind, dealer_index + 1 for big blind
+            let sb_index = (dealer_index - 1) % total_players;
+            let sb_address = players.at(sb_index);
+            let bb_index = (dealer_index + 1) % total_players;
+            let bb_address = players.at(bb_index);
+
+            let mut sb_player: Player = world.read_model(sb_address);
+            let sb_amount = game.params.small_blind;
+            sb_player.chips = sb_player.chips - sb_amount.into();
+            sb_player.current_bet = sb_amount.into();
+            world.write_model(@sb_player);
+
+            let mut bb_player: Player = world.read_model(bb_address);
+            let bb_amount = game.params.big_blind;
+            bb_player.chips = bb_player.chips - bb_amount.into();
+            bb_player.current_bet = bb_amount.into();
+            world.write_model(@bb_player);
+
+            game.pot = (sb_amount + bb_amount).into();
+            game.current_bet = bb_amount.into();
+
+            // Reset previous game state
+            game.round_in_progress = true;
+            game.community_cards = array![];
+            // set raises remaining back to the maximum number
+            // set the game actions taken back to 0
+
+            for deck_id in game.deck.span() {
+                let mut deck: Deck = world.read_model(deck_id);
+                deck.new_deck();
+                deck.shuffle();
+                world.write_model(@deck);
+            };
+
+            // Deal hole cards
+            self._deal_hands(ref players);
+
+            // set player turn
+            let next_player_index = (bb_index + 1) % total_players;
+            let next_player = players.at(next_player_index);
+            game.next_player = Option::Some(*next_player.id);
+
+            world.write_model(@game);
+            world.emit_event(
+                @RoundStarted {
+                    game_id,
+                    dealer: world.read_model(@dealer_index),
+                    current_game_bet: bb_amount.into(),
+                    small_blind_player: sb_player.id,
+                    big_blind_player: bb_player.id,
+                    next_player: *next_player.id,
+                    no_of_players: players.len()
+                }
+            )
         }
 
         // extracts the winning hands

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -6,7 +6,7 @@ pub mod actions {
     use dojo::event::EventStorage;
     use poker::models::base::{
         GameErrors, Id, GameInitialized, CardDealt, HandCreated, HandResolved, RoundResolved,
-        PlayerJoined, PlayerLeft, GameConcluded, RoundStarted
+        PlayerJoined, PlayerLeft, GameConcluded, RoundStarted,
     };
     use poker::models::card::{Card, CardTrait};
     use poker::models::deck::{Deck, DeckTrait};
@@ -787,25 +787,29 @@ pub mod actions {
 
         // @OWK50GA
         // STEP 1:
-            // Change dealer/select dealer: this is because each round has a new dealer. Remember the dealer
-            //  choosing algorithm used in this project
+        // Change dealer/select dealer: this is because each round has a new dealer. Remember the
+        // dealer
+        //  choosing algorithm used in this project
 
-            // STEP 2:
-            // Initialize pots to take small blind and big blind. The small blind guy is the one immediately next 
-            // to the dealer (left hand), while the big blind guy is next to the small blind guy
+        // STEP 2:
+        // Initialize pots to take small blind and big blind. The small blind guy is the one
+        // immediately next to the dealer (left hand), while the big blind guy is next to the small
+        // blind guy
 
-            // STEP 3:
-            // Reset all previous round game variables, including bets and player amounts. Clear round actions as well
-            // so that you can record other actions. Also update the current_bet (minimum players must call to stay in)
+        // STEP 3:
+        // Reset all previous round game variables, including bets and player amounts. Clear round
+        // actions as well so that you can record other actions. Also update the current_bet
+        // (minimum players must call to stay in)
 
-            // STEP 4:
-            // Shuffle, and then deal hole cards. The function is in this contract already
+        // STEP 4:
+        // Shuffle, and then deal hole cards. The function is in this contract already
 
-            // STEP 5:
-            // Set player turn, to the player immediately right of the big blind, so that the engine knows whose turn it is.
+        // STEP 5:
+        // Set player turn, to the player immediately right of the big blind, so that the engine
+        // knows whose turn it is.
 
-            // STEP 6:
-            // Initialize community cards placeholder, and betting counter
+        // STEP 6:
+        // Initialize community cards placeholder, and betting counter
         fn _start_round(ref self: ContractState, game_id: u64, ref players: Array<Player>) {
             // Load world and game
             let mut world = self.world_default();
@@ -829,8 +833,10 @@ pub mod actions {
                 i += 1;
             };
 
-            // Post blinds now you have dealer index. Player to the left for small blind, right for big blind.
-            // We are taking 0 to length as left to right, so dealer_index - 1 for small blind, dealer_index + 1 for big blind
+            // Post blinds now you have dealer index. Player to the left for small blind, right for
+            // big blind.
+            // We are taking 0 to length as left to right, so dealer_index - 1 for small blind,
+            // dealer_index + 1 for big blind
             let sb_index = (dealer_index - 1) % total_players;
             let sb_address = players.at(sb_index);
             let bb_index = (dealer_index + 1) % total_players;
@@ -874,17 +880,18 @@ pub mod actions {
             let dealer: Player = world.read_model(dealer_index);
 
             world.write_model(@game);
-            world.emit_event(
-                @RoundStarted {
-                    game_id,
-                    dealer: dealer.id,
-                    current_game_bet: bb_amount.into(),
-                    small_blind_player: sb_player.id,
-                    big_blind_player: bb_player.id,
-                    next_player: *next_player.id,
-                    no_of_players: players.len()
-                }
-            )
+            world
+                .emit_event(
+                    @RoundStarted {
+                        game_id,
+                        dealer: dealer.id,
+                        current_game_bet: bb_amount.into(),
+                        small_blind_player: sb_player.id,
+                        big_blind_player: bb_player.id,
+                        next_player: *next_player.id,
+                        no_of_players: players.len(),
+                    },
+                )
         }
 
         // extracts the winning hands

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -822,7 +822,7 @@ pub mod actions {
             let mut i = 0;
             while i < total_players {
                 let current_player = players.at(i);
-                if *current_player == next_dealer {
+                if current_player == @next_dealer {
                     dealer_index = i;
                     break;
                 }
@@ -836,13 +836,13 @@ pub mod actions {
             let bb_index = (dealer_index + 1) % total_players;
             let bb_address = players.at(bb_index);
 
-            let mut sb_player: Player = world.read_model(sb_address);
+            let mut sb_player: Player = world.read_model(*sb_address);
             let sb_amount = game.params.small_blind;
             sb_player.chips = sb_player.chips - sb_amount.into();
             sb_player.current_bet = sb_amount.into();
             world.write_model(@sb_player);
 
-            let mut bb_player: Player = world.read_model(bb_address);
+            let mut bb_player: Player = world.read_model(*bb_address);
             let bb_amount = game.params.big_blind;
             bb_player.chips = bb_player.chips - bb_amount.into();
             bb_player.current_bet = bb_amount.into();
@@ -858,7 +858,7 @@ pub mod actions {
             // set the game actions taken back to 0
 
             for deck_id in game.deck.span() {
-                let mut deck: Deck = world.read_model(deck_id);
+                let mut deck: Deck = world.read_model(*deck_id);
                 deck.new_deck();
                 deck.shuffle();
                 world.write_model(@deck);
@@ -871,12 +871,13 @@ pub mod actions {
             let next_player_index = (bb_index + 1) % total_players;
             let next_player = players.at(next_player_index);
             game.next_player = Option::Some(*next_player.id);
+            let dealer: Player = world.read_model(dealer_index);
 
             world.write_model(@game);
             world.emit_event(
                 @RoundStarted {
                     game_id,
-                    dealer: world.read_model(@dealer_index),
+                    dealer: dealer.id,
                     current_game_bet: bb_amount.into(),
                     small_blind_player: sb_player.id,
                     big_blind_player: bb_player.id,


### PR DESCRIPTION
## Description   
No modifications, just additions. 
Added an internal function to the actions.cairo in the game, for starting each round
Added an event, and emitted the event at the end of the start_round function

## Related Issues   
Closes #93 

## Changes Made 
Function summary:
// STEP 1:
            // Change dealer/select dealer: this is because each round has a new dealer. Remember the dealer
            //  choosing algorithm used in this project

            // STEP 2:
            // Initialize pots to take small blind and big blind. The small blind guy is the one immediately next 
            // to the dealer (left hand), while the big blind guy is next to the small blind guy

            // STEP 3:
            // Reset all previous round game variables, including bets and player amounts. Clear round actions as well
            // so that you can record other actions. Also update the current_bet (minimum players must call to stay in)

            // STEP 4:
            // Shuffle, and then deal hole cards. The function is in this contract already

            // STEP 5:
            // Set player turn, to the player immediately right of the big blind, so that the engine knows whose turn it is.

            // STEP 6:
            // Initialize community cards placeholder, and betting counter
  
## Checklist  
- [x] My code follows the project's coding style.  