### PR TITLE
Adjust extract kicker

### DIFF
--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -248,30 +248,26 @@ mod tests {
         let cards = array![c(8, 0), c(8, 1), c(14, 0), c(13, 1), c(2, 2)];
 
         let h1 = mk_hand(p1, cards.clone());
-        let h2 = mk_hand(p2, cards);
+        let h2 = mk_hand(p2, cards.clone());
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into(),
-        );
-        assert(winners.len() == 2, 'Identical pairs should tie');
-        assert(kicker.len() == 0, 'Tie, no kicker');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(kicker.len() == 0, 'Tie means no kicker');
     }
 
     #[test]
     fn test_two_pair_different_high_pair() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
-        // p1: K-K & 2-2
+
         let h1 = mk_hand(p1, array![c(13, 0), c(13, 1), c(2, 0), c(2, 1), c(9, 2)]);
-        // p2: Q-Q & J-J
         let h2 = mk_hand(p2, array![c(12, 2), c(12, 3), c(11, 0), c(11, 1), c(8, 2)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into(),
-        );
-        assert(winners.len() == 1, 'Higher top pair wins');
-        assert(winners.at(0).player == @h1.player, 'Wrong winner on two-pair');
-        assert(kicker == h1.cards, 'Kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h1.player, 'Higher top pair should be first');
+        assert(sorted_hands.at(1).player == @h2.player, 'Lower top pair should be second');
+        assert(kicker == h1.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -319,16 +319,15 @@ mod tests {
     fn test_full_house_different_three() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
-        // p1: 3×A + 2×K, p2: 3×K + 2×Q
+
         let h1 = mk_hand(p1, array![c(14, 0), c(14, 1), c(14, 2), c(13, 0), c(13, 1)]);
         let h2 = mk_hand(p2, array![c(13, 2), c(13, 3), c(13, 1), c(12, 0), c(12, 1)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::FULL_HOUSE.into(),
-        );
-        assert(winners.len() == 1, 'Higher triple wins');
-        assert(winners.at(0).player == @h1.player, 'Wrong winner on full house');
-        assert(kicker == h1.cards, 'Kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::FULL_HOUSE.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h1.player, 'Higher triple should be first');
+        assert(sorted_hands.at(1).player == @h2.player, 'Lower triple should be second');
+        assert(kicker == h1.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -214,18 +214,14 @@ mod tests {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
 
-        // both Ace high…
-        // p1 second-highest = Q
         let h1 = mk_hand(p1, array![c(14, 0), c(12, 1), c(10, 2), c(8, 0), c(6, 1)]);
-        // p2 second-highest = K
         let h2 = mk_hand(p2, array![c(14, 3), c(13, 1), c(9, 0), c(7, 2), c(5, 3)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
-        );
-        assert(winners.len() == 1, 'Expected one winner');
-        assert(winners.at(0).player == @h2.player, 'Higher second-card should win');
-        assert(kicker == h2.cards, 'Kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h2.player, 'Higher 2nd-card should be first');
+        assert(sorted_hands.at(1).player == @h1.player, 'Lower 2nd-card should be second');
+        assert(kicker == h2.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -274,17 +274,15 @@ mod tests {
     fn test_two_pair_same_pairs_different_kicker() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
-        // both K-K & Q-Q…
-        // p1 kicker = 10, p2 kicker = J
+
         let h1 = mk_hand(p1, array![c(13, 0), c(13, 1), c(12, 0), c(12, 1), c(10, 2)]);
         let h2 = mk_hand(p2, array![c(13, 2), c(13, 3), c(12, 2), c(12, 3), c(11, 0)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into(),
-        );
-        assert(winners.len() == 1, 'Higher kicker wins');
-        assert(winners.at(0).player == @h2.player, 'Wrong winner on two-pair kicker');
-        assert(kicker == h2.cards, 'Kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h2.player, 'Higher kicker should be first');
+        assert(sorted_hands.at(1).player == @h1.player, 'Lower kicker should be second');
+        assert(kicker == h2.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -170,16 +170,12 @@ mod tests {
         let player1 = contract_address_const::<'PLAYER1'>();
         let player2 = contract_address_const::<'PLAYER2'>();
 
-        // h1: 10-J-Q-K-A, h2: 9-10-J-Q-K
         let h1 = mk_hand(player1, array![c(10, 0), c(11, 0), c(12, 0), c(13, 0), c(14, 0)]);
         let h2 = mk_hand(player2, array![c(9, 1), c(10, 1), c(11, 1), c(12, 1), c(13, 1)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::STRAIGHT.into(),
-        );
-
-        assert(winners.len() == 2, 'All straights should tie');
-        assert(kicker.len() == 0, 'Straights tie, no kicker');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::STRAIGHT.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(kicker.len() > 0, 'Straights tie, no kicker');
     }
 
     #[test]
@@ -203,17 +199,14 @@ mod tests {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
 
-        // p1: K♣ Q♦ J♠ 10♣ 9♦  (King high)
         let h1 = mk_hand(p1, array![c(13, 0), c(12, 1), c(11, 2), c(10, 0), c(9, 1)]);
-        // p2: A♥ 5♣ 4♦ 3♠ 2♣   (Ace high)
         let h2 = mk_hand(p2, array![c(14, 3), c(5, 0), c(4, 1), c(3, 2), c(2, 0)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
-        );
-        assert(winners.len() == 1, 'Expected one winner');
-        assert(winners.at(0).player == @h2.player, 'Ace-high should win');
-        assert(kicker == h2.cards, 'Kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h2.player, 'Ace-high should be first');
+        assert(sorted_hands.at(1).player == @h1.player, 'King-high should be second');
+        assert(kicker == h2.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -175,7 +175,7 @@ mod tests {
 
         let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::STRAIGHT.into());
         assert(sorted_hands.len() == 2, 'Should return all hands');
-        assert(kicker.len() > 0, 'Straights tie, no kicker');
+        assert(kicker.len() == 0, 'Straights tie, no kicker');
     }
 
     #[test]
@@ -349,27 +349,25 @@ mod tests {
     fn test_straight_flush_tie() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
+
         let h1 = mk_hand(p1, array![c(5, 0), c(6, 0), c(7, 0), c(8, 0), c(9, 0)]);
         let h2 = mk_hand(p2, array![c(2, 1), c(3, 1), c(4, 1), c(5, 1), c(6, 1)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::STRAIGHT_FLUSH.into(),
-        );
-        assert(winners.len() == 2, 'All straight-flush hands tie');
-        assert(kicker.len() == 0, 'Tie, no kicker');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::STRAIGHT_FLUSH.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(kicker.len() == 0, 'Straight flushes tie, no kicker');
     }
 
     #[test]
     fn test_royal_flush_tie() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
+
         let h1 = mk_hand(p1, array![c(10, 2), c(11, 2), c(12, 2), c(13, 2), c(14, 2)]);
         let h2 = mk_hand(p2, array![c(10, 1), c(11, 1), c(12, 1), c(13, 1), c(14, 1)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::ROYAL_FLUSH.into(),
-        );
-        assert(winners.len() == 2, 'All royal-flush hands tie');
-        assert(kicker.len() == 0, 'Tie, no kicker');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::ROYAL_FLUSH.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(kicker.len() == 0, 'Royal flushes tie, no kicker');
     }
 }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -123,19 +123,17 @@ mod tests {
         let player1 = contract_address_const::<'PLAYER1'>();
         let player2 = contract_address_const::<'PLAYER2'>();
 
-        // h1: A♠,K♠,Q♠,J♠,10♠  (ace high)
         let card1 = array![c(14, 0), c(13, 0), c(12, 0), c(11, 0), c(10, 0)];
-        // h2: K♥,Q♥,J♥,10♥,9♥  (king high)
         let card2 = array![c(13, 1), c(12, 1), c(11, 1), c(10, 1), c(9, 1)];
 
         let h1 = mk_hand(player1, card1);
         let h2 = mk_hand(player2, card2);
 
-        let (winners, kicker) = extract_kicker(array![h1.clone(), h2], HandRank::HIGH_CARD.into());
-        assert(winners.len() == 1, 'There should be only 1 winner');
-        assert(winners.at(0).player == @h1.player, 'Wrong winner');
-        // kicker must be the winner’s full 5 cards
-        assert(kicker == h1.cards, 'kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h1.player, 'Strongest hand should be first');
+        assert(sorted_hands.at(1).player == @h2.player, 'Weaker hand should be second');
+        assert(kicker == h1.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -141,16 +141,13 @@ mod tests {
         let player1 = contract_address_const::<'PLAYER1'>();
         let player2 = contract_address_const::<'PLAYER2'>();
 
-        // both hands identical → tie, no kicker
         let cards = array![c(14, 0), c(10, 1), c(8, 2), c(4, 3), c(2, 0)];
         let h1 = mk_hand(player1, cards.clone());
-        let h2 = mk_hand(player2, cards);
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
-        );
+        let h2 = mk_hand(player2, cards.clone());
 
-        assert(winners.len() == 2, 'Both hands should tie');
-        assert(kicker.len() == 0, 'Tie means no kicker returned');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(kicker.len() == 0, 'Tie means no kicker');
     }
 
     #[test]
@@ -158,19 +155,14 @@ mod tests {
         let player1 = contract_address_const::<'PLAYER1'>();
         let player2 = contract_address_const::<'PLAYER2'>();
 
-        // Both have pair of 9s:
-        // h1 kickers = [A, K, 3]
         let h1 = mk_hand(player1, array![c(9, 0), c(9, 1), c(14, 0), c(13, 1), c(3, 2)]);
-        // h2 kickers = [A, Q, 5] → Q < K, so h1 should win
         let h2 = mk_hand(player2, array![c(9, 2), c(9, 3), c(14, 1), c(12, 0), c(5, 1)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into(),
-        );
-
-        assert(winners.len() == 1, 'Only one hand should win');
-        assert(winners.at(0).player == @h1.player, 'Wrong hand won the tie');
-        assert(kicker == h1.cards, 'Winner cards must be returned');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h1.player, 'Strongest hand should be first');
+        assert(sorted_hands.at(1).player == @h2.player, 'Weaker hand should be second');
+        assert(kicker == h1.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -304,17 +304,15 @@ mod tests {
     fn test_flush_different_high() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
-        // p1 flush hearts: A,J,9,7,3 → Ace highest
+
         let h1 = mk_hand(p1, array![c(14, 1), c(11, 1), c(9, 1), c(7, 1), c(3, 1)]);
-        // p2 flush clubs: K,Q,10,8,2 → King highest
         let h2 = mk_hand(p2, array![c(13, 2), c(12, 2), c(10, 2), c(8, 2), c(2, 2)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::FLUSH.into(),
-        );
-        assert(winners.len() == 1, 'Higher flush wins');
-        assert(winners.at(0).player == @h1.player, 'Wrong winner on flush');
-        assert(kicker == h1.cards, 'Kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::FLUSH.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h1.player, 'Higher flush should be first');
+        assert(sorted_hands.at(1).player == @h2.player, 'Lower flush should be second');
+        assert(kicker == h1.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -129,7 +129,9 @@ mod tests {
         let h1 = mk_hand(player1, card1);
         let h2 = mk_hand(player2, card2);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h1.player, 'Strongest hand should be first');
         assert(sorted_hands.at(1).player == @h2.player, 'Weaker hand should be second');
@@ -145,7 +147,9 @@ mod tests {
         let h1 = mk_hand(player1, cards.clone());
         let h2 = mk_hand(player2, cards.clone());
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(kicker.len() == 0, 'Tie means no kicker');
     }
@@ -158,7 +162,9 @@ mod tests {
         let h1 = mk_hand(player1, array![c(9, 0), c(9, 1), c(14, 0), c(13, 1), c(3, 2)]);
         let h2 = mk_hand(player2, array![c(9, 2), c(9, 3), c(14, 1), c(12, 0), c(5, 1)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h1.player, 'Strongest hand should be first');
         assert(sorted_hands.at(1).player == @h2.player, 'Weaker hand should be second');
@@ -173,7 +179,9 @@ mod tests {
         let h1 = mk_hand(player1, array![c(10, 0), c(11, 0), c(12, 0), c(13, 0), c(14, 0)]);
         let h2 = mk_hand(player2, array![c(9, 1), c(10, 1), c(11, 1), c(12, 1), c(13, 1)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::STRAIGHT.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::STRAIGHT.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(kicker.len() == 0, 'Straights tie, no kicker');
     }
@@ -202,7 +210,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(13, 0), c(12, 1), c(11, 2), c(10, 0), c(9, 1)]);
         let h2 = mk_hand(p2, array![c(14, 3), c(5, 0), c(4, 1), c(3, 2), c(2, 0)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h2.player, 'Ace-high should be first');
         assert(sorted_hands.at(1).player == @h1.player, 'King-high should be second');
@@ -217,7 +227,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(14, 0), c(12, 1), c(10, 2), c(8, 0), c(6, 1)]);
         let h2 = mk_hand(p2, array![c(14, 3), c(13, 1), c(9, 0), c(7, 2), c(5, 3)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::HIGH_CARD.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h2.player, 'Higher 2nd-card should be first');
         assert(sorted_hands.at(1).player == @h1.player, 'Lower 2nd-card should be second');
@@ -234,7 +246,9 @@ mod tests {
         // p2: pair of Tens
         let h2 = mk_hand(p2, array![c(10, 2), c(10, 3), c(14, 0), c(2, 1), c(3, 2)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h1.player, 'Higher pair should be first');
         assert(sorted_hands.at(1).player == @h2.player, 'Lower pair should be second');
@@ -250,7 +264,9 @@ mod tests {
         let h1 = mk_hand(p1, cards.clone());
         let h2 = mk_hand(p2, cards.clone());
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(kicker.len() == 0, 'Tie means no kicker');
     }
@@ -263,7 +279,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(13, 0), c(13, 1), c(2, 0), c(2, 1), c(9, 2)]);
         let h2 = mk_hand(p2, array![c(12, 2), c(12, 3), c(11, 0), c(11, 1), c(8, 2)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h1.player, 'Higher top pair should be first');
         assert(sorted_hands.at(1).player == @h2.player, 'Lower top pair should be second');
@@ -278,7 +296,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(13, 0), c(13, 1), c(12, 0), c(12, 1), c(10, 2)]);
         let h2 = mk_hand(p2, array![c(13, 2), c(13, 3), c(12, 2), c(12, 3), c(11, 0)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::TWO_PAIR.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h2.player, 'Higher kicker should be first');
         assert(sorted_hands.at(1).player == @h1.player, 'Lower kicker should be second');
@@ -293,7 +313,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(9, 0), c(9, 1), c(9, 2), c(5, 0), c(4, 1)]);
         let h2 = mk_hand(p2, array![c(8, 0), c(8, 1), c(8, 2), c(14, 0), c(2, 1)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::THREE_OF_A_KIND.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::THREE_OF_A_KIND.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h1.player, 'Higher three should be first');
         assert(sorted_hands.at(1).player == @h2.player, 'Lower three should be second');
@@ -308,7 +330,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(14, 1), c(11, 1), c(9, 1), c(7, 1), c(3, 1)]);
         let h2 = mk_hand(p2, array![c(13, 2), c(12, 2), c(10, 2), c(8, 2), c(2, 2)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::FLUSH.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::FLUSH.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h1.player, 'Higher flush should be first');
         assert(sorted_hands.at(1).player == @h2.player, 'Lower flush should be second');
@@ -323,7 +347,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(14, 0), c(14, 1), c(14, 2), c(13, 0), c(13, 1)]);
         let h2 = mk_hand(p2, array![c(13, 2), c(13, 3), c(13, 1), c(12, 0), c(12, 1)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::FULL_HOUSE.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::FULL_HOUSE.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h1.player, 'Higher triple should be first');
         assert(sorted_hands.at(1).player == @h2.player, 'Lower triple should be second');
@@ -338,7 +364,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(7, 0), c(7, 1), c(7, 2), c(7, 3), c(14, 0)]);
         let h2 = mk_hand(p2, array![c(6, 0), c(6, 1), c(6, 2), c(6, 3), c(13, 0)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::FOUR_OF_A_KIND.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::FOUR_OF_A_KIND.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(sorted_hands.at(0).player == @h1.player, 'Higher four should be first');
         assert(sorted_hands.at(1).player == @h2.player, 'Lower four should be second');
@@ -353,7 +381,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(5, 0), c(6, 0), c(7, 0), c(8, 0), c(9, 0)]);
         let h2 = mk_hand(p2, array![c(2, 1), c(3, 1), c(4, 1), c(5, 1), c(6, 1)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::STRAIGHT_FLUSH.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::STRAIGHT_FLUSH.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(kicker.len() == 0, 'Straight flushes tie, no kicker');
     }
@@ -366,7 +396,9 @@ mod tests {
         let h1 = mk_hand(p1, array![c(10, 2), c(11, 2), c(12, 2), c(13, 2), c(14, 2)]);
         let h2 = mk_hand(p2, array![c(10, 1), c(11, 1), c(12, 1), c(13, 1), c(14, 1)]);
 
-        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::ROYAL_FLUSH.into());
+        let (sorted_hands, kicker) = extract_kicker(
+            array![h1.clone(), h2.clone()], HandRank::ROYAL_FLUSH.into(),
+        );
         assert(sorted_hands.len() == 2, 'Should return all hands');
         assert(kicker.len() == 0, 'Royal flushes tie, no kicker');
     }

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -334,16 +334,15 @@ mod tests {
     fn test_four_of_a_kind_different_four() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
-        // p1: four 7s, p2: four 6s
+
         let h1 = mk_hand(p1, array![c(7, 0), c(7, 1), c(7, 2), c(7, 3), c(14, 0)]);
         let h2 = mk_hand(p2, array![c(6, 0), c(6, 1), c(6, 2), c(6, 3), c(13, 0)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::FOUR_OF_A_KIND.into(),
-        );
-        assert(winners.len() == 1, 'Higher four-of-a-kind wins');
-        assert(winners.at(0).player == @h1.player, 'Wrong winner on four-of-a-kind');
-        assert(kicker == h1.cards, 'Kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::FOUR_OF_A_KIND.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h1.player, 'Higher four should be first');
+        assert(sorted_hands.at(1).player == @h2.player, 'Lower four should be second');
+        assert(kicker == h1.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -255,12 +255,11 @@ mod tests {
         // p2: pair of Tens
         let h2 = mk_hand(p2, array![c(10, 2), c(10, 3), c(14, 0), c(2, 1), c(3, 2)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into(),
-        );
-        assert(winners.len() == 1, 'Higher pair wins');
-        assert(winners.at(0).player == @h1.player, 'Wrong winner on different pairs');
-        assert(kicker == h1.cards, 'Kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::ONE_PAIR.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h1.player, 'Higher pair should be first');
+        assert(sorted_hands.at(1).player == @h2.player, 'Lower pair should be second');
+        assert(kicker == h1.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/models/hand.cairo
+++ b/poker-texas-hold-em/contract/src/models/hand.cairo
@@ -289,16 +289,15 @@ mod tests {
     fn test_three_of_a_kind_different_three() {
         let p1 = contract_address_const::<'P1'>();
         let p2 = contract_address_const::<'P2'>();
-        // p1: three 9s, p2: three 8s
+
         let h1 = mk_hand(p1, array![c(9, 0), c(9, 1), c(9, 2), c(5, 0), c(4, 1)]);
         let h2 = mk_hand(p2, array![c(8, 0), c(8, 1), c(8, 2), c(14, 0), c(2, 1)]);
 
-        let (winners, kicker) = extract_kicker(
-            array![h1.clone(), h2.clone()], HandRank::THREE_OF_A_KIND.into(),
-        );
-        assert(winners.len() == 1, 'Higher three-of-kind wins');
-        assert(winners.at(0).player == @h1.player, 'Wrong winner on three-of-a-kind');
-        assert(kicker == h1.cards, 'Kicker must be winner cards');
+        let (sorted_hands, kicker) = extract_kicker(array![h1.clone(), h2.clone()], HandRank::THREE_OF_A_KIND.into());
+        assert(sorted_hands.len() == 2, 'Should return all hands');
+        assert(sorted_hands.at(0).player == @h1.player, 'Higher three should be first');
+        assert(sorted_hands.at(1).player == @h2.player, 'Lower three should be second');
+        assert(kicker == h1.cards, 'Kicker should be strongest hand');
     }
 
     #[test]

--- a/poker-texas-hold-em/contract/src/traits/handimpl.cairo
+++ b/poker-texas-hold-em/contract/src/traits/handimpl.cairo
@@ -85,7 +85,7 @@ pub impl HandImpl of HandTrait {
         (best_hand, best_rank.into())
     }
 
-    /// @Birdmannn
+    /// @Birdmannn, @pope-h
     fn compare_hands(
         hands: Array<Hand>, community_cards: Array<Card>, game_params: GameParams,
     ) -> (Span<Hand>, HandRank, Span<Card>) {

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -31,31 +31,25 @@ fn extract_kicker(hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array<Car
         || rank == HandRank::STRAIGHT_FLUSH
         || rank == HandRank::ROYAL_FLUSH {
         let mut sorted_hands: Array<Hand> = array![];
-        let mut i: usize = 0;
-        while i < hands.len() {
+        for i in 0..hands.len() {
             sorted_hands.append(hands.at(i).clone());
-            i += 1;
         };
         return (sorted_hands, array![]);
     }
 
     let mut keys_and_hands: Array<(Array<u16>, Hand)> = array![];
-    let mut i: usize = 0;
-    while i < hands.len() {
+    for i in 0..hands.len() {
         let hand = hands.at(i);
         assert(hand.cards.len() == 5, 'Hand must have 5 cards');
         let key = get_key(hand, rank);
         keys_and_hands.append((key, hand.clone()));
-        i += 1;
     };
 
     let sorted = bubble_sort_keys_and_hands(keys_and_hands);
     let mut sorted_hands: Array<Hand> = array![];
-    i = 0;
-    while i < sorted.len() {
+    for i in 0..sorted.len() {
         let (_, hand) = sorted.at(i);
         sorted_hands.append(hand.clone());
-        i += 1;
     };
 
     let mut kicker: Array<Card> = array![];
@@ -225,16 +219,13 @@ fn bubble_sort_u8(mut arr: Array<u8>) -> Array<u8> {
     let mut swapped = true;
     while swapped {
         swapped = false;
-        let mut i: usize = 0;
-        while i < arr.len() - 1 {
-            let current = *arr.at(i);
-            let next = *arr.at(i + 1);
-            if current < next {
-                arr = set_array_element(arr.clone(), i, next);
-                arr = set_array_element(arr, i + 1, current);
+        for i in 0..arr.len() - 1 {
+            if *arr.at(i) < *arr.at(i + 1) {
+                let temp = *arr.at(i);
+                arr = set_array_element(arr.clone(), i, *arr.at(i + 1));
+                arr = set_array_element(arr, i + 1, temp);
                 swapped = true;
             };
-            i += 1;
         };
     };
     arr
@@ -612,11 +603,10 @@ fn compare_arrays(a: @Array<u16>, b: @Array<u16>) -> felt252 {
 /// [@pope-h]
 fn bit_and(a: u32, b: u32) -> u32 {
     let mut result = 0_u32;
-    let mut position = 0_u32;
     let mut a_copy = a;
     let mut b_copy = b;
 
-    while position < 32 {
+    for position in 0..32_u32 {
         let bit_a = a_copy % 2;
         let bit_b = b_copy % 2;
         if bit_a == 1 && bit_b == 1 {
@@ -624,7 +614,6 @@ fn bit_and(a: u32, b: u32) -> u32 {
         };
         a_copy /= 2;
         b_copy /= 2;
-        position += 1;
     };
     result
 }
@@ -644,10 +633,8 @@ fn bit_and(a: u32, b: u32) -> u32 {
 /// [@pope-h]
 fn pow(base: u32, exp: u32) -> u32 {
     let mut result = 1_u32;
-    let mut i = 0_u32;
-    while i < exp {
+    for _i in 0..exp {
         result *= base;
-        i += 1;
     };
     result
 }

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -26,6 +26,17 @@ fn extract_kicker(hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array<Car
     assert(hands.len() > 0, 'Hands array cannot be empty');
     let rank: HandRank = hand_rank.into();
 
+    // For STRAIGHT, STRAIGHT_FLUSH, and ROYAL_FLUSH, return all hands with no kicker
+    if rank == HandRank::STRAIGHT || rank == HandRank::STRAIGHT_FLUSH || rank == HandRank::ROYAL_FLUSH {
+        let mut sorted_hands: Array<Hand> = array![];
+        let mut i: usize = 0;
+        while i < hands.len() {
+            sorted_hands.append(hands.at(i).clone());
+            i += 1;
+        };
+        return (sorted_hands, array![]);
+    }
+
     let mut keys_and_hands: Array<(Array<u16>, Hand)> = array![];
     let mut i: usize = 0;
     while i < hands.len() {

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -67,6 +67,7 @@ fn extract_kicker(hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array<Car
 }
 
 /// Extracts the comparison key for a hand based on its rank.
+/// @pope-h
 fn get_key(hand: @Hand, rank: HandRank) -> Array<u16> {
     match rank {
         HandRank::HIGH_CARD | HandRank::FLUSH => get_high_card_key(hand),
@@ -82,6 +83,7 @@ fn get_key(hand: @Hand, rank: HandRank) -> Array<u16> {
 }
 
 /// Sorts an array of (key, hand) pairs in descending order based on the key.
+/// @pope-h
 fn bubble_sort_keys_and_hands(mut arr: Array<(Array<u16>, Hand)>) -> Array<(Array<u16>, Hand)> {
     let mut swapped = true;
     while swapped {

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -27,7 +27,9 @@ fn extract_kicker(hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array<Car
     let rank: HandRank = hand_rank.into();
 
     // For STRAIGHT, STRAIGHT_FLUSH, and ROYAL_FLUSH, return all hands with no kicker
-    if rank == HandRank::STRAIGHT || rank == HandRank::STRAIGHT_FLUSH || rank == HandRank::ROYAL_FLUSH {
+    if rank == HandRank::STRAIGHT
+        || rank == HandRank::STRAIGHT_FLUSH
+        || rank == HandRank::ROYAL_FLUSH {
         let mut sorted_hands: Array<Hand> = array![];
         let mut i: usize = 0;
         while i < hands.len() {
@@ -77,7 +79,8 @@ fn get_key(hand: @Hand, rank: HandRank) -> Array<u16> {
         HandRank::ONE_PAIR => get_one_pair_key(hand),
         HandRank::TWO_PAIR => get_two_pair_key(hand),
         HandRank::THREE_OF_A_KIND => get_three_of_a_kind_key(hand),
-        HandRank::STRAIGHT | HandRank::STRAIGHT_FLUSH | HandRank::ROYAL_FLUSH => get_high_card_key(hand),
+        HandRank::STRAIGHT | HandRank::STRAIGHT_FLUSH |
+        HandRank::ROYAL_FLUSH => get_high_card_key(hand),
         HandRank::FULL_HOUSE => get_full_house_key(hand),
         HandRank::FOUR_OF_A_KIND => get_four_of_a_kind_key(hand),
         HandRank::UNDEFINED => panic(array!['Undefined hand rank']),
@@ -238,7 +241,9 @@ fn bubble_sort_u8(mut arr: Array<u8>) -> Array<u8> {
 }
 
 /// @pope-h
-fn set_array_element<T, +Clone<T>, +Drop<T>>(mut arr: Array<T>, index: usize, value: T) -> Array<T> {
+fn set_array_element<T, +Clone<T>, +Drop<T>>(
+    mut arr: Array<T>, index: usize, value: T,
+) -> Array<T> {
     let mut new_arr: Array<T> = array![];
     for i in 0..arr.len() {
         if i == index {

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -238,6 +238,25 @@ fn get_key(hand: @Hand, rank: HandRank) -> Array<u16> {
     }
 }
 
+/// Sorts an array of (key, hand) pairs in descending order based on the key.
+fn bubble_sort_keys_and_hands(mut arr: Array<(Array<u16>, Hand)>) -> Array<(Array<u16>, Hand)> {
+    let mut swapped = true;
+    while swapped {
+        swapped = false;
+        for i in 0..arr.len() - 1 {
+            let (key1, _) = arr.at(i);
+            let (key2, _) = arr.at(i + 1);
+            if compare_arrays(key1, key2) == -1 {
+                let temp = arr.at(i).clone();
+                arr = set_array_element(arr.clone(), i, arr.at(i + 1).clone());
+                arr = set_array_element(arr, i + 1, temp);
+                swapped = true;
+            };
+        };
+    };
+    arr
+}
+
 /// @pope-h
 fn generate_combinations(cards: Array<Card>, k: usize) -> Array<Array<Card>> {
     let n = cards.len();
@@ -373,16 +392,14 @@ fn bubble_sort_u8(mut arr: Array<u8>) -> Array<u8> {
 }
 
 /// @pope-h
-fn set_array_element<T, +Copy<T>, +Drop<T>>(mut arr: Array<T>, index: usize, value: T) -> Array<T> {
+fn set_array_element<T, +Clone<T>, +Drop<T>>(mut arr: Array<T>, index: usize, value: T) -> Array<T> {
     let mut new_arr: Array<T> = array![];
-    let mut i: usize = 0;
-    while i < arr.len() {
+    for i in 0..arr.len() {
         if i == index {
-            new_arr.append(value);
+            new_arr.append(value.clone());
         } else {
-            new_arr.append(*arr.at(i));
+            new_arr.append(arr.at(i).clone());
         };
-        i += 1;
     };
     new_arr
 }

--- a/poker-texas-hold-em/contract/src/utils/hand.cairo
+++ b/poker-texas-hold-em/contract/src/utils/hand.cairo
@@ -3,10 +3,9 @@ use crate::models::card::{Card, Royals};
 
 /// Determines the winning hand(s) among an array of hands with the same HandRank.
 ///
-/// This function compares hands of equal rank using poker tie-breaking rules specific to each
-/// HandRank. It assumes all input hands have the same rank and contain exactly 5 cards.
-/// For ranks like STRAIGHT, STRAIGHT_FLUSH, and ROYAL_FLUSH, where ties are determined solely
-/// by the rank itself, all hands are considered equal if they share the same rank.
+/// This function sorts all hands in descending order based on their strength and returns them,
+/// along with kicker cards determined by poker tie-breaking rules specific to each HandRank.
+/// It assumes all input hands have the same rank and contain exactly 5 cards.
 ///
 /// # Arguments
 /// * `hands` - An array of Hand structs, each with the same HandRank.
@@ -14,10 +13,10 @@ use crate::models::card::{Card, Royals};
 ///
 /// # Returns
 /// A tuple containing:
-/// 1. An `Array<Hand>` of the winning hand(s).
+/// 1. An `Array<Hand>` of all hands sorted in descending order by strength.
 /// 2. An `Array<Card>` of kicker cards:
-///    - If a single hand wins, contains all 5 cards of that hand.
-///    - If multiple hands tie, contains an empty array, indicating no further tie-breaking.
+///    - If the first hand is uniquely the strongest, contains all 5 cards of that hand.
+///    - If multiple hands tie for the strongest, contains an empty array.
 ///
 /// # Panics
 /// Panics if the input `hands` array is empty or if any hand does not have exactly 5 cards.
@@ -222,6 +221,20 @@ fn extract_kicker(mut hands: Array<Hand>, hand_rank: u16) -> (Array<Hand>, Array
             }
         },
         HandRank::UNDEFINED => { panic(array!['Undefined hand rank']) },
+    }
+}
+
+/// Extracts the comparison key for a hand based on its rank.
+fn get_key(hand: @Hand, rank: HandRank) -> Array<u16> {
+    match rank {
+        HandRank::HIGH_CARD | HandRank::FLUSH => get_high_card_key(hand),
+        HandRank::ONE_PAIR => get_one_pair_key(hand),
+        HandRank::TWO_PAIR => get_two_pair_key(hand),
+        HandRank::THREE_OF_A_KIND => get_three_of_a_kind_key(hand),
+        HandRank::STRAIGHT | HandRank::STRAIGHT_FLUSH | HandRank::ROYAL_FLUSH => get_high_card_key(hand),
+        HandRank::FULL_HOUSE => get_full_house_key(hand),
+        HandRank::FOUR_OF_A_KIND => get_four_of_a_kind_key(hand),
+        HandRank::UNDEFINED => panic(array!['Undefined hand rank']),
     }
 }
 


### PR DESCRIPTION
## Description   
The changes modify the extract_kicker function to correctly filter winning hands based on the highest kicker key and update the compare_hands function to ensure proper winner selection and kicker handling. Additionally, the test was updated to remove an ambiguous assertion about card equality, focusing on the core requirements.   

## Related Issues   
- Fixes #124 
- Addresses failing test test_compare_one_pair_kicker_split_true in the test suite.  

## Changes Made   - [ ] 
- Updated to sort all input hands in descending order based on their comparison keys (using get_key and bubble_sort_keys_and_hands).
- Returns all hands in sorted_hands, not just the winning hand(s), ensuring the strongest hand is at index 0.
- Maintains the kicker array to include the cards of the strongest hand when there is a single winner, or an empty array for ties.
- Special handling for STRAIGHT, STRAIGHT_FLUSH, and ROYAL_FLUSH to return all hands unsorted with an empty kicker array, as these ranks tie without kicker comparison. 
- Updated compare_hands fn
- Fixed Test Cases

## How to Test  
Navigate to the contract folder and run `sozo build` then `sozo test`   
 
## Screenshots (if applicable)  
<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->    
  
## Checklist  
- [X] My code follows the project's coding style.  
- [X] I have tested these changes locally.   
- [X] Documentation has been updated where necessary.  