### PR TITLE
feat: Implemented merkle traits and build root, part 1

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -2,12 +2,16 @@ name: Contracts CI
 on:
   push:
     branches: 
-      - "main"
-      - "v1"
+      - main
+    paths:
+      - '**'
+      - '**'
   pull_request:
     branches: 
-      - "main"
-      - "v1"
+      - main
+    paths:
+      - '**'
+      - '**'
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -2,12 +2,12 @@ name: Contracts CI
 on:
   push:
     branches: 
-      - main
-      - '**'
-  # pull_request:
-  #   branches: 
-  #     - main
-  #     - '**'
+      - "main"
+      - "v1"
+  pull_request:
+    branches: 
+      - "main"
+      - "v1"
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -3,12 +3,14 @@ on:
   push:
     branches: 
       - main
+      - '**'
     paths:
       - '**'
       - '**'
   pull_request:
     branches: 
       - main
+      - '**'
     paths:
       - '**'
       - '**'

--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -1,4 +1,5 @@
 name: Contracts CI
+
 on:
   push:
     branches: 

--- a/poker-texas-hold-em/contract/src/lib.cairo
+++ b/poker-texas-hold-em/contract/src/lib.cairo
@@ -27,7 +27,6 @@ mod utils {
 }
 
 #[cfg(test)]
-#[ignore]
 mod tests {
     mod setup;
     mod test_actions;

--- a/poker-texas-hold-em/contract/src/lib.cairo
+++ b/poker-texas-hold-em/contract/src/lib.cairo
@@ -22,9 +22,12 @@ mod traits {
 
 mod utils {
     mod hand;
+    mod game;
+    mod deck;
 }
 
 #[cfg(test)]
+#[ignore]
 mod tests {
     mod setup;
     mod test_actions;

--- a/poker-texas-hold-em/contract/src/models/base.cairo
+++ b/poker-texas-hold-em/contract/src/models/base.cairo
@@ -26,7 +26,7 @@ pub struct CardDealt {
     pub deck_id: u64,
     pub time_stamp: u64,
     // pub card_value: u8,
-    // pub card_suit: u16,
+// pub card_suit: u16,
 }
 
 #[derive(Copy, Drop, Serde)]

--- a/poker-texas-hold-em/contract/src/models/base.cairo
+++ b/poker-texas-hold-em/contract/src/models/base.cairo
@@ -25,6 +25,8 @@ pub struct CardDealt {
     pub player_id: ContractAddress,
     pub deck_id: u64,
     pub time_stamp: u64,
+    // pub card_value: u8,
+    // pub card_suit: u16,
 }
 
 #[derive(Copy, Drop, Serde)]

--- a/poker-texas-hold-em/contract/src/models/card.cairo
+++ b/poker-texas-hold-em/contract/src/models/card.cairo
@@ -1,6 +1,8 @@
 use core::num::traits::Zero;
+use core::poseidon::PoseidonTrait;
+use core::hash::{HashStateTrait, HashStateExTrait};
 
-#[derive(Copy, Drop, Serde, Default, Debug, Introspect, PartialEq)]
+#[derive(Copy, Drop, Serde, Default, Debug, Introspect, PartialEq, Hash)]
 pub struct Card {
     suit: u8,
     value: u16,
@@ -68,6 +70,20 @@ pub impl CardImpl of CardTrait {
 
     fn is_valid(self: @Card) -> bool {
         self.value.is_non_zero()
+    }
+
+    fn hash(ref self: Card, salt: Array<felt252>) -> felt252 {
+        // static 3 for now. Might be dynamic later.
+        assert(salt.len() == 3, 'SALT IS EMPTY');
+        let mut serialized_data: Array<felt252> = array![];
+        self.serialize(ref serialized_data);
+        let hash = PoseidonTrait::new()
+            .update_with(self)
+            .update_with(*salt.at(1))
+            .update_with(*salt.at(0))
+            .update_with(*salt.at(2))
+            .finalize();
+        hash
     }
 }
 // Should implement into?

--- a/poker-texas-hold-em/contract/src/models/deck.cairo
+++ b/poker-texas-hold-em/contract/src/models/deck.cairo
@@ -123,7 +123,6 @@ mod tests {
     // 3. The order of cards has changed (deck is actually shuffled)
     // TODO: Fix the DeckTrait [`shuffle()`] function to make the test pass
     #[test]
-    // #[ignore]
     fn test_shuffle() {
         let mut deck: Deck = Deck { id: 1, cards: array![] };
         deck.new_deck();

--- a/poker-texas-hold-em/contract/src/models/game.cairo
+++ b/poker-texas-hold-em/contract/src/models/game.cairo
@@ -65,6 +65,8 @@ pub struct Game {
     current_bet: u256,
     params: GameParams,
     reshuffled: u64,
+    deck_root: felt252,
+    dealt_cards_root: felt252,
 }
 
 #[derive(Drop, Clone, Serde)]
@@ -72,7 +74,7 @@ pub struct Game {
 pub struct GameStats {
     #[key]
     game_id: u64,
-    mvp: ContractAddress
+    mvp: ContractAddress,
 }
 
 // then we can implemnt a list node here

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -445,6 +445,7 @@ pub mod actions {
         // @nagxsan
         fn update(ref self: ContractState, game_id: u64, updated_game_stats: GameStats) {
             let mut world: dojo::world::WorldStorage = self.world_default();
+            // remove this _game_stats in the future.
             let _game_stats: GameStats = world.read_model(game_id);
             world.write_model(@updated_game_stats);
         }
@@ -750,9 +751,7 @@ pub mod actions {
             // the remaining fields would be left for stats
             let mvp = self.extract_mvp(game.id);
             let game_concluded = GameConcluded {
-                game_id: game.id,
-                time_stamp: get_block_timestamp(),
-                mvp,
+                game_id: game.id, time_stamp: get_block_timestamp(), mvp,
             };
             world.emit_event(@game_concluded);
         }

--- a/poker-texas-hold-em/contract/src/tests/test_actions.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_actions.cairo
@@ -346,6 +346,8 @@ mod tests {
             params: get_default_game_params(),
             reshuffled: 0,
             should_end: false,
+            deck_root: 0,
+            dealt_cards_root: 0,
         };
 
         let player_1 = Player {

--- a/poker-texas-hold-em/contract/src/tests/test_hand_compare.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_hand_compare.cairo
@@ -41,7 +41,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[test]  
     fn test_compare_one_pair_kicker_split_true() {
         let p1_addr = contract_address_const::<'P1'>();
         let p2_addr = contract_address_const::<'P2'>();

--- a/poker-texas-hold-em/contract/src/tests/test_hand_compare.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_hand_compare.cairo
@@ -41,7 +41,7 @@ mod tests {
         }
     }
 
-    #[test]  
+    #[test]
     fn test_compare_one_pair_kicker_split_true() {
         let p1_addr = contract_address_const::<'P1'>();
         let p2_addr = contract_address_const::<'P2'>();

--- a/poker-texas-hold-em/contract/src/utils/deck.cairo
+++ b/poker-texas-hold-em/contract/src/utils/deck.cairo
@@ -1,0 +1,5 @@
+// A circuit that verifies that all cards are shuffled and distinct from one another
+
+/// another might take in a list of dealt cards and assert that they're from this deck.
+
+

--- a/poker-texas-hold-em/contract/src/utils/game.cairo
+++ b/poker-texas-hold-em/contract/src/utils/game.cairo
@@ -215,6 +215,7 @@ pub mod Tests {
     }
 
     #[test]
+    #[ignore]
     fn test_merkle_generate_root_success() {
         let cards = default_hand();
     }


### PR DESCRIPTION
## Description   
This PR contains the on-chain computation of generating a merkle root. In the v2 version, an off chain computation might be required, but this is to ensure transparency in processing and generating proofs that we leave everything that can be on-chain, on chain. This merkle root is used in storing and verifying proof of cards in the game, and proof of cards dealt. This root is changed every round. There is currently no on-chain version of implementing merkle traits. 

This trait takes in an array of Cards and hashes them using a `vrf` provided salt. It builds the tree and returns the root. The root is stored on-chain, while the leaf-nodes used in generating that root is to be returned to the admin caller of the game round start flow.

This PR handles all computation in the zero knowledge of player hands. A test shall be written in addendum to this.

## Related Issues   
<!-- Link any related issues using `Closes #issue_number` or `Fixes #issue_number`. This helps track bugs and feature requests. -->    
Fixes #129 

## Changes Made   - [ ] 
- generate_proof
- new
- get_root
- verify.

These were all utility functions in `utils/game.cairo`  

## How to Test  
`sozo test`

## Screenshots (if applicable)  
<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->    
  
## Checklist  
- [x] My code follows the project's coding style.  
- [ ] I have tested these changes locally.   
- [ ] Documentation has been updated where necessary.  