### PR TITLE
community card dealing

### DIFF
--- a/poker-texas-hold-em/contract/src/models/base.cairo
+++ b/poker-texas-hold-em/contract/src/models/base.cairo
@@ -25,8 +25,8 @@ pub struct CardDealt {
     pub player_id: ContractAddress,
     pub deck_id: u64,
     pub time_stamp: u64,
-    // pub card_value: u8,
-// pub card_suit: u16,
+    pub card_value: u8,
+    pub card_suit: u16,
 }
 
 #[derive(Copy, Drop, Serde)]

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -551,16 +551,6 @@ pub mod actions {
 
                     world.write_model(@deck); // should work, ;)
                     current_index += 1;
-
-                    world
-                        .emit_event(
-                            @CardDealt {
-                                game_id: *game_id,
-                                player_id: *player.id,
-                                deck_id: deck.id,
-                                time_stamp: starknet::get_block_timestamp(),
-                            },
-                        );
                 };
 
                 world.write_model(@hand);
@@ -794,6 +784,17 @@ pub mod actions {
             let card = deck.deal_card();
 
             game.community_cards.append(card);
+
+            world.emit_event(
+                @CardDealt {
+                    game_id: game_id,
+                    player_id: get_contract_address(), // or use a special address for community cards
+                    deck_id: deck.id,
+                    time_stamp: get_block_timestamp(),
+                    card_value: card.value,
+                    card_suit: card.suit,
+                },
+            );
 
             world.write_model(@deck);
             world.write_model(@game);


### PR DESCRIPTION
## Description   
Fix the community card dealing 

## Related Issues   
 Closes #153 

## Changes Made   
Uncomment the remaining fields in the CardsDealt event struct in models/base.cairo

Removed 
```world
    .emit_event(
        @CardDealt {
            game_id: *game_id,
            player_id: *player.id,
            deck_id: deck.id,
            time_stamp: starknet::get_block_timestamp(),
        },
    ); 
```


from the _deal_hands function in system/action.cairo  and added
```world.emit_event(
    @CardDealt {
        game_id: game_id,
        player_id: get_contract_address(), // or use a special address for community cards
        deck_id: deck.id,
        time_stamp: get_block_timestamp(),
        card_value: card.value,
        card_suit: card.suit,
    },
);
```
in _deal_community_card function



