### PR TITLE
feat: verify_game

### DIFF
--- a/poker-texas-hold-em/GameREADME.md
+++ b/poker-texas-hold-em/GameREADME.md
@@ -124,3 +124,6 @@ fn clone_array(cards: @Array<Card>) -> Array<Card> {
     };
     new_array
 }
+
+/// New
+

--- a/poker-texas-hold-em/contract/src/models/game.cairo
+++ b/poker-texas-hold-em/contract/src/models/game.cairo
@@ -1,5 +1,6 @@
 use starknet::ContractAddress;
 use super::card::Card;
+use super::hand::Hand;
 use poker::traits::game::GameTrait;
 use core::num::traits::Zero;
 
@@ -67,6 +68,18 @@ pub struct Game {
     reshuffled: u64,
     deck_root: felt252,
     dealt_cards_root: felt252,
+}
+
+#[derive(Drop, Serde, Copy)]
+#[dojo::model]
+pub struct Salts {
+    #[key]
+    id1: felt252,
+    #[key]
+    id2: felt252,
+    #[key]
+    id3: felt252,
+    used: bool,
 }
 
 // #[derive(Drop, Copy, PartialEq, Default, Serde, Instrospect)]

--- a/poker-texas-hold-em/contract/src/models/game.cairo
+++ b/poker-texas-hold-em/contract/src/models/game.cairo
@@ -52,10 +52,10 @@ pub struct Game {
     #[key]
     id: u64,
     in_progress: bool,
+    round_in_progress: bool,
     has_ended: bool,
     current_round: u8,
     should_end: bool,
-    round_in_progress: bool,
     current_player_count: u32,
     players: Array<ContractAddress>,
     deck: Array<u64>,
@@ -68,6 +68,14 @@ pub struct Game {
     deck_root: felt252,
     dealt_cards_root: felt252,
 }
+
+// #[derive(Drop, Copy, PartialEq, Default, Serde, Instrospect)]
+// pub enum RoundStatus {
+//     #[default]
+//     IsWaiting,
+//     InProgress,
+//     HasEnded,
+// }
 
 #[derive(Drop, Clone, Serde)]
 #[dojo::model]

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -275,7 +275,7 @@ pub mod actions {
             deck: Deck,
             game_salt: Array<felt252>,
             dealt_card_salt: Array<felt252>,
-        ) {// let mut world = self.world_default();
+        ) { // let mut world = self.world_default();
         // assert that this game is valid
         // NOTE: CALLER CAN BE ZERO, FOR NOW.
         // assert that the game round has ended.

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -2,7 +2,7 @@
 #[dojo::contract]
 pub mod actions {
     use starknet::{ContractAddress, get_caller_address, get_contract_address, get_block_timestamp};
-    use dojo::model::{ModelStorage, ModelValueStorage};
+    use dojo::model::{ModelStorage, ModelValueStorage, Model};
     use dojo::event::EventStorage;
     use poker::models::base::{
         GameErrors, Id, GameInitialized, CardDealt, HandCreated, HandResolved, RoundResolved,
@@ -262,6 +262,30 @@ pub mod actions {
 
         fn get_dealer(self: @ContractState) -> Option<Player> {
             Option::None
+        }
+
+        fn deal_community_card(ref self: ContractState, card: Card, game_id: u256) {}
+
+        fn showdown(
+            ref self: ContractState,
+            game_id: u64,
+            hands: Array<Hand>,
+            game_proofs: Array<Array<felt252>>,
+            dealt_card_proofs: Array<Array<felt252>>,
+            deck: Deck,
+            game_salt: Array<felt252>,
+            dealt_card_salt: Array<felt252>,
+        ) {
+            let mut world = self.world_default();
+            // assert that this game is valid
+            // NOTE: CALLER CAN BE ZERO, FOR NOW.
+            // assert that the game round has ended.
+            // check the game_params, if the game is verifiable
+            // else, users should use the `submit_card` endpoint.
+            // assert that the salt is not a used salt.
+            let mut game: Game = world.read_model(game_id);
+            // in the end, record this salt as a used salt
+        // set both roots to zero in the `resolve_game`
         }
 
 

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -275,16 +275,15 @@ pub mod actions {
             deck: Deck,
             game_salt: Array<felt252>,
             dealt_card_salt: Array<felt252>,
-        ) {
-            let mut world = self.world_default();
-            // assert that this game is valid
-            // NOTE: CALLER CAN BE ZERO, FOR NOW.
-            // assert that the game round has ended.
-            // check the game_params, if the game is verifiable
-            // else, users should use the `submit_card` endpoint.
-            // assert that the salt is not a used salt.
-            let mut game: Game = world.read_model(game_id);
-            // in the end, record this salt as a used salt
+        ) {// let mut world = self.world_default();
+        // assert that this game is valid
+        // NOTE: CALLER CAN BE ZERO, FOR NOW.
+        // assert that the game round has ended.
+        // check the game_params, if the game is verifiable
+        // else, users should use the `submit_card` endpoint.
+        // assert that the salt is not a used salt.
+        // let mut game: Game = world.read_model(game_id);
+        // in the end, record this salt as a used salt
         // set both roots to zero in the `resolve_game`
         }
 

--- a/poker-texas-hold-em/contract/src/systems/interface.cairo
+++ b/poker-texas-hold-em/contract/src/systems/interface.cairo
@@ -1,5 +1,8 @@
 use poker::models::game::{Game, GameParams};
+use poker::models::card::Card;
+use poker::models::hand::Hand;
 use poker::models::player::Player;
+use poker::models::deck::Deck;
 use starknet::ContractAddress;
 use poker::traits::game::get_default_game_params;
 
@@ -34,8 +37,20 @@ trait IActions<TContractState> {
     fn all_in(ref self: TContractState);
     fn buy_in(ref self: TContractState, no_of_chips: u256); // will call
     fn get_dealer(self: @TContractState) -> Option<Player>;
+    // remove
     fn get_rank(self: @TContractState, player_id: ContractAddress) -> ByteArray;
-
+    // to be called by the dealer, for now.
+    fn deal_community_card(ref self: TContractState, card: Card, game_id: u256);
+    fn showdown(
+        ref self: TContractState,
+        game_id: u64,
+        hands: Array<Hand>,
+        game_proofs: Array<Array<felt252>>,
+        dealt_card_proofs: Array<Array<felt252>>,
+        deck: Deck,
+        game_salt: Array<felt252>,
+        dealt_card_salt: Array<felt252>,
+    );
 
     /// All functions here might be extracted into a separate contract
     fn get_player(self: @TContractState, player_id: ContractAddress) -> Player;

--- a/poker-texas-hold-em/contract/src/traits/deck.cairo
+++ b/poker-texas-hold-em/contract/src/traits/deck.cairo
@@ -74,8 +74,22 @@ pub impl DeckImpl of DeckTrait {
         self.cards = shuffled_cards;
     }
 
+    fn append(ref self: Deck, card: Card) {
+        self.cards.append(card);
+    }
+
     fn deal_card(ref self: Deck) -> Card {
         self.cards.pop_front().unwrap()
+    }
+
+    fn is_shuffled(ref self: Deck) -> bool {
+        // for the implementation, check if at least 1/2 of self.new_deck() is at a
+        // different position.
+        true
+    }
+
+    fn is_cards_distinct(ref self: Deck) -> bool {
+        true
     }
 }
 // assert after shuffling, that all cards remain distinct, and the deck is still 52 cards

--- a/poker-texas-hold-em/contract/src/traits/handtrait.cairo
+++ b/poker-texas-hold-em/contract/src/traits/handtrait.cairo
@@ -29,8 +29,7 @@ pub trait HandTrait {
     /// 1. A new Hand with the best 5 cards found
     /// 2. The rank of the hand as HandRank
     ///
-    /// # Panics
-    /// Panics if the total number of cards is not exactly 7
+    /// no panic
     fn rank(self: @Hand, community_cards: Array<Card>) -> (Hand, HandRank);
 
     /// @Birdmannn

--- a/poker-texas-hold-em/contract/src/utils/deck.cairo
+++ b/poker-texas-hold-em/contract/src/utils/deck.cairo
@@ -44,7 +44,7 @@ pub fn verify_game(
     deck.cards = array![];
     // append dealt hands first.
     for i in 0..hands.len() {
-        let hand = hands.get(i).unwrap();
+        let hand = hands.at(i);
         for j in 0..hand.cards.len() {
             deck.append(*hand.cards.at(j));
         };
@@ -74,38 +74,31 @@ pub fn verify_game(
     let mut card_index = 0;
     let mut deck_verified = false;
     let mut card_verified = false;
-    for i in 0..hands.len() {
-        let hand = hands.get(i).unwrap();
-        for mut card in hand.cards.clone() {
+    for hand in hands {
+        // let hand = hands.get(i).unwrap().unbox();
+        for mut card in hand.cards {
             // it should take two at a time for the array of proofs
-            deck_verified =
-                verify(ref game_proofs, game_root, ref card, game_salt.clone(), card_index);
+            let proof = game_proofs.pop_front().unwrap();
+            let dealt_card_proof = dealt_cards_proofs.pop_front().unwrap();
+            deck_verified = verify(proof, game_root, card, game_salt.clone(), card_index);
             card_verified =
                 verify(
-                    ref dealt_cards_proofs,
-                    dealt_cards_root,
-                    ref card,
-                    dealt_card_salt.clone(),
-                    card_index,
+                    dealt_card_proof, dealt_cards_root, card, dealt_card_salt.clone(), card_index,
                 );
-            if !deck_verified || card_verified {
+
+            if !deck_verified || !card_verified {
                 break;
             }
         };
-        card_index += 1;
     };
 
     deck_verified && card_verified
 }
 
 fn verify(
-    ref proofs: Array<Array<felt252>>,
-    root: felt252,
-    ref card: Card,
-    salt: Array<felt252>,
-    index: usize,
+    proof: Array<felt252>, root: felt252, mut card: Card, salt: Array<felt252>, index: usize,
 ) -> bool {
-    MerkleTrait::verify_v2(proofs.pop_front().unwrap(), root, card.hash(salt), index)
+    MerkleTrait::verify_v2(proof, root, card.hash(salt), index)
 }
 
 #[cfg(test)]
@@ -113,13 +106,89 @@ mod Tests {
     use super::verify_game;
     use crate::models::game::Game;
     use crate::models::deck::{Deck, DeckTrait};
-    use crate::models::card::Card;
+    use crate::models::card::{Card, Suits, Royals};
+    use crate::models::hand::{Hand, HandTrait};
+    use super::super::game::{MerkleTrait, MerkleState};
+
+    fn card(suit: u8, value: u16) -> Card {
+        Card { suit, value }
+    }
 
     #[test]
-    fn test_verify_game_success() {}
+    fn test_verify_game_success() {
+        let mut deck: Deck = Default::default();
+        let salt1 = array!['SALT1', 'SALT2', 'SALT3'];
+        let salt2 = array!['SALT4', 'SALT5', 'SALT6'];
+        deck.new_deck();
+        deck.shuffle();
+        let mut deck_state = MerkleTrait::new(deck.cards.clone(), salt1.clone());
+
+        // deal cards
+        let mut player1_hand = HandTrait::default();
+        let mut player2_hand = HandTrait::default();
+        let mut player_cards = array![];
+
+        // index 1 and 2, for player1, and 3 and 4 for player2
+        for _ in 0..2_u32 {
+            let card = deck.deal_card();
+            player1_hand.add_card(card);
+            player_cards.append(card);
+        };
+
+        for _ in 0..2_u32 {
+            let card = deck.deal_card();
+            player2_hand.add_card(card);
+            player_cards.append(card);
+        };
+
+        let mut dealt_cards_state = MerkleTrait::new(player_cards.clone(), salt2.clone());
+        let mut community_cards = array![];
+        for _ in 0..5_u32 {
+            community_cards.append(deck.deal_card());
+        };
+
+        let hands = array![player1_hand, player2_hand];
+        let mut game_proofs = array![];
+        let mut dealt_cards_proofs = array![];
+        for i in 0..player_cards.len() {
+            let proof = deck_state.generate_proof_v2(i.into());
+            game_proofs.append(proof);
+            let proof = dealt_cards_state.generate_proof_v2(i.into());
+            dealt_cards_proofs.append(proof);
+        };
+        let game_root = deck_state.get_root();
+        println!("Game root in test: {}", game_root);
+        let dealt_cards_root = dealt_cards_state.get_root();
+
+        let is_verified = verify_game(
+            community_cards,
+            hands,
+            game_proofs,
+            dealt_cards_proofs,
+            deck,
+            game_root,
+            dealt_cards_root,
+            salt1,
+            salt2,
+        );
+
+        assert(is_verified, 'UNABLE TO VERIFY GAME');
+    }
 
     #[test]
-    fn test_verify_game_on_wrong_proof() {}
+    fn test_verify_game_on_wrong_proof() {// for a tw player game
+    // pub fn verify_game(
+    //     community_cards: Array<Card>,
+    //     hands: Array<Hand>,
+    //     mut game_proofs: Array<Array<felt252>>,
+    //     mut dealt_cards_proofs: Array<Array<felt252>>,
+    //     mut deck: Deck,
+    //     game_root: felt252,
+    //     dealt_cards_root: felt252,
+    //     game_salt: Array<felt252>,
+    //     dealt_card_salt: Array<felt252>,
+    // )
+    }
 
     #[test]
     fn test_verify_game_on_wrong_data() { // this should be a fuzz test, by the way... if necessary.

--- a/poker-texas-hold-em/contract/src/utils/deck.cairo
+++ b/poker-texas-hold-em/contract/src/utils/deck.cairo
@@ -1,5 +1,128 @@
-// A circuit that verifies that all cards are shuffled and distinct from one another
+/// A logic that verifies that all cards are shuffled and distinct from one another
 
-/// another might take in a list of dealt cards and assert that they're from this deck.
+use crate::models::card::{Card, CardTrait};
+use crate::models::deck::{Deck, DeckTrait};
+use crate::models::hand::Hand;
+use super::game::MerkleTrait;
 
+/// @Birdmannn
+/// Verifies the deck in sync with the whole game.
+///
+/// Implements lazy verification
+/// This function ensures that the whole gameplay was indeed performed accurately, after the game
+/// round has been concluded.
+///
+/// # Arguments
+/// * `community_cards` - An array of community cards dealt in the round
+/// * `hands` - An array of player hands submitted during showdown
+/// * `proofs` - Merkle proofs of player hands for verification
+/// * `deck` - The current deck used in playing the game
+/// * `game_root` - The merkle root of the deck in the game.
+/// * `dealt_cards_root` - The merkle root of the dealt cards in the game
+/// * `salt` - The salt used for cards commitment
+///
+/// # Returns
+/// bool - if the game was valid.
+/// no panic
+/// TODO: IN THE FUTURE, PLEASE USE OPENZEPPELIN FOR MERKLE TREE VERIFICATION
+pub fn verify_game(
+    community_cards: Array<Card>,
+    hands: Array<Hand>,
+    mut game_proofs: Array<Array<felt252>>,
+    mut dealt_cards_proofs: Array<Array<felt252>>,
+    mut deck: Deck,
+    game_root: felt252,
+    dealt_cards_root: felt252,
+    game_salt: Array<felt252>,
+    dealt_card_salt: Array<felt252>,
+) -> bool {
+    assert(community_cards.len() == 5, 'COMMUNITY CARDS != 5');
+    assert(hands.len() == game_proofs.len() / 2, 'PROOFS AND HANDS LEN MISMATCH');
+    assert(hands.len() == dealt_cards_proofs.len() / 2, 'PROOFS AND HANDS LEN MISMATCH.');
+    // rebuild deck, and compute the root.
+    let deck_cards = deck.cards;
+    deck.cards = array![];
+    // append dealt hands first.
+    for i in 0..hands.len() {
+        let hand = hands.get(i).unwrap();
+        for j in 0..hand.cards.len() {
+            deck.append(*hand.cards.at(j));
+        };
+    };
+
+    // append community cards next.
+    for i in 0..community_cards.len() {
+        deck.append(*community_cards.at(i));
+    };
+
+    // then append the remaining deck cards
+    for card in deck_cards {
+        deck.append(card);
+    };
+
+    if !deck.is_shuffled() || !deck.is_cards_distinct() {
+        return false;
+    }
+
+    // SWITCH TO OPENZEPPELIN IN THE FUTURE
+    let mut merkle_state = MerkleTrait::new(deck.cards, game_salt.clone());
+    if merkle_state.get_root() != game_root {
+        return false;
+    }
+
+    // verify these hands were in the deck
+    let mut card_index = 0;
+    let mut deck_verified = false;
+    let mut card_verified = false;
+    for i in 0..hands.len() {
+        let hand = hands.get(i).unwrap();
+        for mut card in hand.cards.clone() {
+            // it should take two at a time for the array of proofs
+            deck_verified =
+                verify(ref game_proofs, game_root, ref card, game_salt.clone(), card_index);
+            card_verified =
+                verify(
+                    ref dealt_cards_proofs,
+                    dealt_cards_root,
+                    ref card,
+                    dealt_card_salt.clone(),
+                    card_index,
+                );
+            if !deck_verified || card_verified {
+                break;
+            }
+        };
+        card_index += 1;
+    };
+
+    deck_verified && card_verified
+}
+
+fn verify(
+    ref proofs: Array<Array<felt252>>,
+    root: felt252,
+    ref card: Card,
+    salt: Array<felt252>,
+    index: usize,
+) -> bool {
+    MerkleTrait::verify_v2(proofs.pop_front().unwrap(), root, card.hash(salt), index)
+}
+
+#[cfg(test)]
+mod Tests {
+    use super::verify_game;
+    use crate::models::game::Game;
+    use crate::models::deck::{Deck, DeckTrait};
+    use crate::models::card::Card;
+
+    #[test]
+    fn test_verify_game_success() {}
+
+    #[test]
+    fn test_verify_game_on_wrong_proof() {}
+
+    #[test]
+    fn test_verify_game_on_wrong_data() { // this should be a fuzz test, by the way... if necessary.
+    }
+}
 

--- a/poker-texas-hold-em/contract/src/utils/deck.cairo
+++ b/poker-texas-hold-em/contract/src/utils/deck.cairo
@@ -89,6 +89,7 @@ pub fn verify_game(
             if !deck_verified || !card_verified {
                 break;
             }
+            card_index += 1;
         };
     };
 

--- a/poker-texas-hold-em/contract/src/utils/deck.cairo
+++ b/poker-texas-hold-em/contract/src/utils/deck.cairo
@@ -177,7 +177,7 @@ mod Tests {
     }
 
     #[test]
-    fn test_verify_game_on_wrong_proof() {// for a tw player game
+    fn test_verify_game_on_wrong_proof() { // for a tw player game
     // pub fn verify_game(
     //     community_cards: Array<Card>,
     //     hands: Array<Hand>,


### PR DESCRIPTION
## Description   
<!-- Provide a brief summary of the changes in this PR. Explain what was modified and why. -->    
This function is to be used in the `showdown` entry point, where all game data is submitted to ascertain that the game was handled properly without any alterations. The functions handles all necessary verifications on the game assets matched to the commitment earlier stored at the beginning of the game and returns a `bool` on whether or not the verification completed successfully.


Tests have been added as proof that the `verify_game` works and computes successfully. Edge cases tests would be added in the future.

The `showdown` function has been implemented, and all security checks have been made before proceeding to verify the game. Here, if the function is called wrongly, the salt has been exposed, and the round is terminated and verified as `false`. The logic makes it possible that an exposed salt is never used again.

update in `resolve_round_v2` in another issue, and further security checks in another issue by verifying signed messages.

## Related Issues   
<!-- Link any related issues using `Closes #issue_number` or `Fixes #issue_number`. This helps track bugs and feature requests. -->    

## Changes Made   - [ ] 
<!-- List key changes made in this PR. Use bullet points for clarity. -->    

## How to Test  
<!-- Explain how a reviewer can test these changes. Provide commands, steps, or expected results if applicable. -->    
 
## Screenshots (if applicable)  
<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->    
  
## Checklist  
- [x] My code follows the project's coding style.  
- [ ] I have tested these changes locally.   
- [x] Documentation has been updated where necessary.  