### PR TITLE
feat(#161): showdown signature verification

### DIFF
--- a/poker-texas-hold-em/contract/src/models/game.cairo
+++ b/poker-texas-hold-em/contract/src/models/game.cairo
@@ -68,6 +68,7 @@ pub struct Game {
     reshuffled: u64,
     deck_root: felt252,
     dealt_cards_root: felt252,
+    nonce: u64,
 }
 
 #[derive(Drop, Serde, Copy)]

--- a/poker-texas-hold-em/contract/src/models/player.cairo
+++ b/poker-texas-hold-em/contract/src/models/player.cairo
@@ -23,6 +23,7 @@ pub struct Player {
     is_dealer: bool,
     in_round: bool,
     out: (u64, u64),
+    pub_key: felt252,
 }
 /// Write struct for player stats
 /// Include an alias, if necessary, and add it as key.
@@ -40,6 +41,7 @@ impl PlayerDefault of Default<Player> {
             is_dealer: false,
             in_round: false,
             out: (0, 0),
+            pub_key: 0,
         }
     }
 }

--- a/poker-texas-hold-em/contract/src/systems/interface.cairo
+++ b/poker-texas-hold-em/contract/src/systems/interface.cairo
@@ -50,6 +50,10 @@ trait IActions<TContractState> {
         deck: Deck,
         game_salt: Array<felt252>,
         dealt_card_salt: Array<felt252>,
+        signature_r: Array<felt252>,
+        signature_s: Array<felt252>,
+        signature_y_parity: Array<bool>, // to recover the public key
+        nonce: u64,
     );
 
     /// All functions here might be extracted into a separate contract

--- a/poker-texas-hold-em/contract/src/tests/test_actions.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_actions.cairo
@@ -348,6 +348,7 @@ mod tests {
             should_end: false,
             deck_root: 0,
             dealt_cards_root: 0,
+            nonce: 0,
         };
 
         let player_1 = Player {
@@ -360,6 +361,7 @@ mod tests {
             is_dealer: false,
             in_round: true,
             out: (0, 0),
+            pub_key: 0x1,
         };
 
         let player_2 = Player {
@@ -372,6 +374,7 @@ mod tests {
             is_dealer: false,
             in_round: true,
             out: (0, 0),
+            pub_key: 0x2,
         };
 
         let player_3 = Player {
@@ -384,6 +387,7 @@ mod tests {
             is_dealer: false,
             in_round: true,
             out: (0, 0),
+            pub_key: 0x3,
         };
 
         world.write_model(@game);

--- a/poker-texas-hold-em/contract/src/tests/test_resolve_round.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_resolve_round.cairo
@@ -109,6 +109,7 @@ mod tests {
             should_end: false,
             deck_root: 0,
             dealt_cards_root: 0,
+            nonce: 0,
         };
 
         let player_1 = Player {
@@ -121,6 +122,7 @@ mod tests {
             is_dealer: false,
             in_round: true,
             out: (0, 0),
+            pub_key: 0x1,
         };
 
         let player_2 = Player {
@@ -133,6 +135,7 @@ mod tests {
             is_dealer: false,
             in_round: true,
             out: (0, 0),
+            pub_key: 0x2,
         };
 
         let player_3 = Player {
@@ -145,6 +148,7 @@ mod tests {
             is_dealer: false,
             in_round: true,
             out: (0, 0),
+            pub_key: 0x3,
         };
 
         world.write_model(@game);


### PR DESCRIPTION
## Description   
Implemented signature verification in the showdown function to ensure that each player's hand is authorized by their ECDSA signature. This includes recovering the public key from the signature, comparing it with the stored public key, verifying the player is part of the current game round, and preventing replay attacks with a nonce.

Testing turned out to be complex due to the need for valid signatures on the secp256r1 curve. A comprehensive test suite with proper signature generation is planned for a follow-up PR.



## Related Issues   
Closes #161

## Changes Made
- Added signature parameters (r, s arrays, y_parity, nonce) to showdown function
- Computed Poseidon hash of hand + nonce as message hash for signature verification
- Implemented public key recovery from signature using [`recover_public_key`](https://docs.cairo-lang.org/core/core-ecdsa-recover_public_key.html) (same name but different from the one in the issue #161 where it returns a point on the curve[this one](https://docs.cairo-lang.org/core/core-starknet-secp256_trait-recover_public_key.html) )
- Added comparison between recovered public key and stored player public key
- Verified player participation in current game round
- Incremented nonce to prevent replay attacks and ensure game state persistence
- Added additional ECDSA signature verification using `check_ecdsa_signature`
- Implemented comprehensive error handling and input validation
- Added array bounds safety checks for signature parameters
- Updated Player model to include pub_key field for signature verification

## How to Test  
- Deploy the contract and call the showdown function with valid hands and corresponding signatures
- Ensure that invalid signatures or mismatched nonces cause the function to revert with appropriate error messages
- Verify that the nonce increments after a successful showdown call
- Test with mismatched signature array lengths to verify input validation
- Confirm that players not in the current round are rejected


## Screenshots (if applicable)  
N/A

## Checklist  
- [x] My code follows the project's coding style
- [x] I have tested these changes locally (manual verification)
- [ ] Documentation has been updated where necessary
