### PR TITLE
Adjusted `after_play`

### DIFF
--- a/poker-texas-hold-em/contract/src/models/base.cairo
+++ b/poker-texas-hold-em/contract/src/models/base.cairo
@@ -4,6 +4,7 @@
 /// Events
 use poker::models::game::GameParams;
 use starknet::ContractAddress;
+use poker::models::card::Card;
 
 /// EVENTS
 
@@ -98,6 +99,24 @@ pub struct RoundStarted {
     pub small_blind_player: ContractAddress,
     pub next_player: ContractAddress,
     pub no_of_players: u32,
+}
+
+#[derive(Drop, Serde)]
+#[dojo::event]
+pub struct RoundEnded {
+    #[key]
+    pub game_id: u64,
+    pub timestamp: u64,
+    pub round_number: u64,
+    pub no_of_players: u32,
+}
+
+#[derive(Drop, Serde)]
+#[dojo::event]
+pub struct CommunityCardDealt {
+    #[key]
+    pub game_id: u64,
+    pub card: Card,
 }
 
 /// MODEL

--- a/poker-texas-hold-em/contract/src/models/game.cairo
+++ b/poker-texas-hold-em/contract/src/models/game.cairo
@@ -69,6 +69,10 @@ pub struct Game {
     deck_root: felt252,
     dealt_cards_root: felt252,
     nonce: u64,
+    community_dealing: bool,
+    showdown: bool,
+    round_count: u64,
+    highest_staker: Option<ContractAddress>,
 }
 
 #[derive(Drop, Serde, Copy)]

--- a/poker-texas-hold-em/contract/src/models/game.cairo
+++ b/poker-texas-hold-em/contract/src/models/game.cairo
@@ -99,7 +99,7 @@ pub struct GameStats {
     mvp: ContractAddress,
 }
 
-// then we can implemnt a list node here
+// then we can implement a list node here
 #[derive(Drop, Serde, Copy, PartialEq)]
 pub struct Node {
     pub val: ContractAddress,

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -268,6 +268,7 @@ pub mod actions {
             Option::None
         }
 
+        /// @Birdmannn
         fn deal_community_card(
             ref self: ContractState, card: Card, game_id: u64,
         ) { // verify signature on this function too. in the future
@@ -490,7 +491,7 @@ pub mod actions {
             );
         }
 
-        /// @Reentrancy
+        /// @Reentrancy, @Birdmannn
         fn after_play(ref self: ContractState, caller: ContractAddress) {
             let mut world = self.world_default();
             let mut player: Player = world.read_model(caller);

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -390,7 +390,7 @@ pub mod actions {
                 community_cards.clone(), hands.clone(), gp, dcp, dc, deck_root, dealt_root, g, d,
             );
 
-            self._resolve_round_v2(hands, community_cards, verified);
+            self._resolve_round_v2(game_id, hands, community_cards, verified);
         }
 
 
@@ -712,28 +712,33 @@ pub mod actions {
 
         fn _resolve_round_v2(
             ref self: ContractState,
+            game_id: u64,
             hands: Array<Hand>,
             community_cards: Array<Card>,
             verified: bool,
         ) { // resolve root
-        // check if verified, by the way.
-        // DO NOT DELETE.
-        // in the future, check if the game should be verifiable, else, users should use the
-        // submit card endpoint.
-        // TODO: call `resolve_game()`, and update the `resolve_game()` with its appropriate
-        // logic.
-        // if game is not verified, read funds in the id, and split together with contract
-        // accordingly.
-        // perhaps let `resolve_game()` take in a bool to assert that the game was resolved
-        // accordingly.
-        // write a new internal function `resolve_v2`
+            let mut world = self.world_default();
+            let mut game: Game = world.read_model(game_id);
+            // check if verified, by the way.
+            // DO NOT DELETE.
+            // in the future, check if the game should be verifiable, else, users should use the
+            // submit card endpoint.
+            // TODO: call `resolve_game()`, and update the `resolve_game()` with its appropriate
+            // logic.
+            // if game is not verified, read funds in the id, and split together with contract
+            // accordingly.
+            // perhaps let `resolve_game()` take in a bool to assert that the game was resolved
+            // accordingly.
+            // write a new internal function `resolve_v2`
 
-        // assert that this game is valid
-        // NOTE: CALLER CAN BE ZERO, FOR NOW.
-        // check the game_params, if the game is verifiable
-        // else, users should use the `submit_card` endpoint.
-        // set both roots to zero in the `resolve_game`
-        // set round_in_progress to false, by the way.
+            // assert that this game is valid
+            // NOTE: CALLER CAN BE ZERO, FOR NOW.
+            // check the game_params, if the game is verifiable
+            // else, users should use the `submit_card` endpoint.
+            // set both roots to zero in the `resolve_game`
+            // set round_in_progress to false, by the way.
+            // update the round_count
+            game.showdown = false;
         }
 
         fn _resolve_hands(

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -270,7 +270,16 @@ pub mod actions {
 
         fn deal_community_card(
             ref self: ContractState, card: Card, game_id: u256,
-        ) { // verify signature on this function too.
+        ) { // verify signature on this function too. in the future
+            // the caller of this function must have some amount of money staked in the game
+            // if the showdown fails to be verified, then the stake is gone.
+            let mut world = self.world_default();
+            let g_key = Model::<Game>::ptr_from_keys(game_id);
+            let in_progress: bool = world.read_member(g_key, selector!("in_progress"));
+            let mut community_cards: Array<Card> = world.read_member(g_key, selector!("community_cards"));
+            assert(in_progress && community_cards.len() <= 5, 'INVALID DEALING');
+            community_cards.append(card);
+            world.write_member(g_key, selector!("community_cards"), community_cards);
         }
 
         fn submit_card(ref self: ContractState, card: felt252) {}

--- a/poker-texas-hold-em/contract/src/systems/interface.cairo
+++ b/poker-texas-hold-em/contract/src/systems/interface.cairo
@@ -41,7 +41,9 @@ trait IActions<TContractState> {
     fn get_rank(self: @TContractState, player_id: ContractAddress) -> ByteArray;
     // to be called by the dealer, for now.
     fn deal_community_card(ref self: TContractState, card: Card, game_id: u256);
-    fn submit_card(ref self: TContractState, card: felt252);    // here, a player can only be in one game at a time.
+    fn submit_card(
+        ref self: TContractState, card: felt252,
+    ); // here, a player can only be in one game at a time.
     fn showdown(
         ref self: TContractState,
         game_id: u64,

--- a/poker-texas-hold-em/contract/src/systems/interface.cairo
+++ b/poker-texas-hold-em/contract/src/systems/interface.cairo
@@ -40,7 +40,7 @@ trait IActions<TContractState> {
     // remove
     fn get_rank(self: @TContractState, player_id: ContractAddress) -> ByteArray;
     // to be called by the dealer, for now.
-    fn deal_community_card(ref self: TContractState, card: Card, game_id: u256);
+    fn deal_community_card(ref self: TContractState, card: Card, game_id: u64);
     fn submit_card(
         ref self: TContractState, card: felt252,
     ); // here, a player can only be in one game at a time.

--- a/poker-texas-hold-em/contract/src/tests/test_actions.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_actions.cairo
@@ -349,6 +349,10 @@ mod tests {
             deck_root: 0,
             dealt_cards_root: 0,
             nonce: 0,
+            community_dealing: false,
+            showdown: false,
+            round_count: 0,
+            highest_staker: Option::None,
         };
 
         let player_1 = Player {

--- a/poker-texas-hold-em/contract/src/tests/test_resolve_round.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_resolve_round.cairo
@@ -110,6 +110,10 @@ mod tests {
             deck_root: 0,
             dealt_cards_root: 0,
             nonce: 0,
+            community_dealing: false,
+            showdown: false,
+            round_count: 0,
+            highest_staker: Option::None,
         };
 
         let player_1 = Player {


### PR DESCRIPTION
## Description   
<!-- Provide a brief summary of the changes in this PR. Explain what was modified and why. -->    
This PR implements the external `deal_community_card` with its appropriate checks and state changes, and also addresses and fixes the issue with the after play in making sure all players' bets are equalled before the next community card is dealt, or before the showdown is possible.

## Related Issues   
Closes #121   

## Changes Made   - [ ] 
<!-- List key changes made in this PR. Use bullet points for clarity. -->    

## How to Test  
<!-- Explain how a reviewer can test these changes. Provide commands, steps, or expected results if applicable. -->    
 
## Screenshots (if applicable)  
<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->    
  
## Checklist  
- [x] My code follows the project's coding style.  
- [ ] I have tested these changes locally.   
- [ ] Documentation has been updated where necessary.  