### PR TITLE
Pot adjustment finality. Adjusted stake of player to match pots

### DIFF
--- a/poker-texas-hold-em/contract/src/traits/player.cairo
+++ b/poker-texas-hold-em/contract/src/traits/player.cairo
@@ -22,6 +22,13 @@ pub impl PlayerImpl of PlayerTrait {
         self.in_round = false;
         self.locked = (false, 0);
 
+        if let ShowdownType::Splitted(stake) = game.params.showdown_type {
+            if self.locked_chips == stake {
+                self.chips += stake;
+                self.locked_chips = 0;
+            }
+        }
+
         game.current_player_count -= 1;
     }
 
@@ -51,13 +58,15 @@ pub impl PlayerImpl of PlayerTrait {
             if stake >= self.chips {
                 return false;
             }
+            if self.locked_chips == stake {
+                return true;
+            }
             let amt = self.chips - stake;
             if game.params.min_amount_of_chips >= amt {
                 return false;
             }
             self.chips -= stake;
             self.locked_chips += stake;
-            return true;
         }
         true
     }


### PR DESCRIPTION
## Description   
<!-- Provide a brief summary of the changes in this PR. Explain what was modified and why. -->    
Closes #183 

Closes the description written in the issue. This effect on when there are two or more pots, and the player is more than one pot behind. This PR would be the final PR done on pots during stakes. 
The next task would involve testing of this work, and splitting of these pots to players accurately and appropriately.

## Related Issues   
<!-- Link any related issues using `Closes #issue_number` or `Fixes #issue_number`. This helps track bugs and feature requests. -->    

## Changes Made   - [ ] 
<!-- List key changes made in this PR. Use bullet points for clarity. -->    

## How to Test  
<!-- Explain how a reviewer can test these changes. Provide commands, steps, or expected results if applicable. -->    
 
## Screenshots (if applicable)  
<!-- If your PR affects the UI, upload screenshots to show the changes visually. -->    
  
## Checklist  
- [ ] My code follows the project's coding style.  
- [ ] I have tested these changes locally.   
- [ ] Documentation has been updated where necessary.  