### PR TITLE
enhance gameplay logic

### DIFF
--- a/poker-texas-hold-em/contract/Scarb.toml
+++ b/poker-texas-hold-em/contract/Scarb.toml
@@ -2,6 +2,7 @@
 cairo-version = "=2.10.1"
 name = "poker"
 version = "1.1.0"
+edition = "2023_10"
 
 [cairo]
 sierra-replace-ids = true

--- a/poker-texas-hold-em/contract/src/models/game.cairo
+++ b/poker-texas-hold-em/contract/src/models/game.cairo
@@ -27,6 +27,7 @@ pub struct GameParams {
     kicker_split: bool,
     min_amount_of_chips: u256,
     blind_spacing: u16,
+    bet_spacing: u256, // Added for bet amount validation
     showdown_type: ShowdownType,
 }
 

--- a/poker-texas-hold-em/contract/src/models/game.cairo
+++ b/poker-texas-hold-em/contract/src/models/game.cairo
@@ -27,7 +27,7 @@ pub struct GameParams {
     kicker_split: bool,
     min_amount_of_chips: u256,
     blind_spacing: u16,
-    bet_spacing: u256, // Added for bet amount validation
+    bet_spacing: u256,
     showdown_type: ShowdownType,
 }
 

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -906,13 +906,13 @@ pub mod actions {
                     // If next player is the highest staker, the betting round is complete
                     match game.highest_staker {
                         Option::Some(staker) => next_player_addr == staker,
-                        Option::None => false
+                        Option::None => false,
                     }
                 },
                 Option::None => {
                     // No next player means only one player remains (others folded)
                     true
-                }
+                },
             }
         }
 
@@ -920,14 +920,16 @@ pub mod actions {
         fn reset_betting_round(
             ref self: ContractState, game_id: u64, ref game: Game, ref world: WorldStorage,
         ) {
-           
             world
                 .write_member(
                     Model::<Game>::ptr_from_keys(game_id),
                     selector!("highest_staker"),
                     Option::<ContractAddress>::None,
                 );
-            world.write_member(Model::<Game>::ptr_from_keys(game_id), selector!("current_bet"), 0_u256);
+            world
+                .write_member(
+                    Model::<Game>::ptr_from_keys(game_id), selector!("current_bet"), 0_u256,
+                );
 
             // Update local game reference
             game.highest_staker = Option::None;

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -293,10 +293,12 @@ pub mod actions {
                 no_of_chips > game_current_bet, "Raise amount is less than the game's current bet.",
             );
 
-            // Validate bet spacing - raise amount must be in multiples of bet_spacing @kaylahray
-            assert!(
-                no_of_chips % params.bet_spacing.into() == 0,
-                "Raise amount must be in multiples of bet_spacing",
+         // Validate bet spacing - raise amount must be in multiples of bet_spacing @kaylahray
+            let bet_spacing = params.bet_spacing;
+            // Only the increment after current_bet needs to be multiple of bet_spacing. @kaylahray
+            let raise_delta = no_of_chips - game_current_bet;
+            assert(
+                raise_delta % bet_spacing.into() == 0, 'Invalid raise spacing'
             );
 
             // adjust this pot accordingly
@@ -316,16 +318,12 @@ pub mod actions {
                 player.current_bet += total_required;
                 game_pot += total_required;
             }
-            game_current_bet = player.current_bet;
 
-            // Set the player as highest staker after successful raise @kaylahray
-            let highest_staker_selector = selector!("highest_staker");
-            world
-                .write_member(
-                    Model::<Game>::ptr_from_keys(game_id),
-                    highest_staker_selector,
-                    Option::Some(player.id),
-                );
+            game_current_bet = player.current_bet;
+            // @Kaylahray 👇
+           world.write_member(Model::<Game>::ptr_from_keys(game_id), selector!("highest_staker"), Option::Some(player.id));
+           
+            
 
             let mut updated_game_pots: Array<u256> = ArrayTrait::new();
             let mut i = 0;
@@ -342,6 +340,7 @@ pub mod actions {
             self.after_play(player.id);
         }
 
+       
         /// @dub_zn
         fn all_in(ref self: ContractState) {
             let mut world = self.world_default();
@@ -350,34 +349,34 @@ pub mod actions {
             // check the previous pot here.
             let game_id: u64 = *player.extract_current_game_id();
             let amount = player.chips;
-
+            
             let cb = selector!("current_bet");
-            let mut game_current_bet = world.read_member(Model::<Game>::ptr_from_keys(game_id), cb);
+            let game_current_bet = world.read_member(Model::<Game>::ptr_from_keys(game_id), cb);
 
-            if amount < game_current_bet {
-                self.adjust_pot(game_id, ref player, game_current_bet);
-                world.write_model(@player);
-            } else {
-                // If all-in amount is >= current bet, player becomes highest staker @kaylahray
-                let new_bet = player.current_bet + amount;
-                if new_bet > game_current_bet {
-                    let highest_staker_selector = selector!("highest_staker");
-                    world
-                        .write_member(
-                            Model::<Game>::ptr_from_keys(game_id),
-                            highest_staker_selector,
-                            Option::Some(player.id),
-                        );
-                    // Update game's current bet @kaylahray
-                    world.write_member(Model::<Game>::ptr_from_keys(game_id), cb, new_bet);
-                }
+            // Update player state for all-in   @kaylahray
+            player.current_bet += amount;
+            player.chips = 0;
 
-                // Update player state @kaylahray
-                player.current_bet += amount;
-                player.chips = 0;
-                world.write_model(@player);
+            // @kaylahray Set highest_staker if this all-in creates new highest bet
+            if player.current_bet > game_current_bet {
+                world.write_member(
+                    Model::<Game>::ptr_from_keys(game_id), 
+                    selector!("highest_staker"), 
+                    Option::Some(player.id)
+                );
+                world.write_member(
+                    Model::<Game>::ptr_from_keys(game_id), 
+                    cb, 
+                    player.current_bet
+                );
             }
 
+            // Handle side pot creation if needed
+            if amount < game_current_bet {
+                self.adjust_pot(game_id, ref player, game_current_bet);
+            }
+            
+            world.write_model(@player);
             self.after_play(player.id);
         }
 
@@ -564,88 +563,6 @@ pub mod actions {
         /// can't be const.
         fn world_default(self: @ContractState) -> WorldStorage {
             self.world(@"poker")
-        }
-
-        /// @Kaylahray Checks if betting round has concluded by verifying all active players have
-        /// equal bets
-        fn is_betting_round_concluded(
-            self: @ContractState, game_id: u64, world: @WorldStorage,
-        ) -> bool {
-            let game: Game = world.read_model(game_id);
-            let game_players = game.players.span();
-
-            let mut highest_bet: u256 = 0;
-            let mut active_player_count: u32 = 0;
-
-            // First pass: find the highest bet among active players
-            let mut i: u32 = 0;
-            while i < game_players.len() {
-                let player_addr = *game_players.at(i);
-                let player: Player = world.read_model(player_addr);
-
-                if player.in_round {
-                    active_player_count += 1;
-                    if player.current_bet > highest_bet {
-                        highest_bet = player.current_bet;
-                    }
-                }
-                i += 1;
-            };
-
-            if active_player_count <= 1 {
-                return true;
-            }
-
-            // Second pass: check if all active players who are not all-in have matched the highest
-            // bet
-            let mut all_matched = true;
-            let mut j: u32 = 0;
-            while j < game_players.len() {
-                let player_addr = *game_players.at(j);
-                let player: Player = world.read_model(player_addr);
-
-                if player.in_round {
-                    // Players who are all-in (0 chips) are exempt from matching
-                    if player.chips > 0 && player.current_bet != highest_bet {
-                        all_matched = false;
-                        break;
-                    }
-                }
-                j += 1;
-            };
-
-            all_matched
-        }
-
-        /// @kaylahray Resets betting values when a round concludes
-        fn reset_betting_round_values(self: @ContractState, game_id: u64, ref world: WorldStorage) {
-            let game: Game = world.read_model(game_id);
-            let game_players = game.players.span();
-
-            let mut i = 0;
-            while i < game_players.len() {
-                let player_addr = *game_players.at(i);
-                // Directly write to the player's current_bet field
-                world
-                    .write_member(
-                        Model::<Player>::ptr_from_keys(player_addr),
-                        selector!("current_bet"),
-                        0_u256,
-                    );
-                i += 1;
-            };
-
-            // Reset game's current_bet and highest_staker
-            world
-                .write_member(
-                    Model::<Game>::ptr_from_keys(game_id), selector!("current_bet"), 0_u256,
-                );
-            world
-                .write_member(
-                    Model::<Game>::ptr_from_keys(game_id),
-                    selector!("highest_staker"),
-                    Option::<ContractAddress>::None,
-                );
         }
 
         fn generate_id(self: @ContractState, target: felt252) -> u64 {
@@ -892,48 +809,121 @@ pub mod actions {
             );
         }
 
+              /// @Reentrancy, @Birdmannn
         fn after_play(ref self: ContractState, caller: ContractAddress) {
             let mut world = self.world_default();
-            let player: Player = world.read_model(caller);
+            let mut player: Player = world.read_model(caller);
             let (is_locked, game_id) = player.locked;
+
+            // Ensure the player is in a game
             assert(is_locked, 'Player not in game');
 
             let mut game: Game = world.read_model(game_id);
 
-            let betting_concluded = self.is_betting_round_concluded(game_id, @world);
-
-            if betting_concluded {
-                self.reset_betting_round_values(game_id, ref world);
-                game = world.read_model(game_id); // Reload game state
-
-                if game.community_cards.len() == 5 {
-                    game.showdown = true;
-                } else {
-                    game.community_dealing = true;
-                }
+            // Check if all community cards are dealt (5 cards in Texas Hold'em)
+            if game.community_cards.len() == 5 {
+                game.showdown = true;
             }
 
-            // Now, set the next player
-            if game.showdown {
-                game.next_player = Option::None;
-            } else {
-                let current_index_option = self.find_player_index(@game.players, caller);
-                assert(current_index_option.is_some(), 'Caller not in game');
-                let current_index = OptionTrait::unwrap(current_index_option);
-                let next_player_option = self
-                    .find_next_active_player(@game.players, current_index, @world);
+            // Find the caller's index in the players array
+            let current_index_option: Option<usize> = self.find_player_index(@game.players, caller);
+            assert(current_index_option.is_some(), 'Caller not in game');
+            let current_index: usize = OptionTrait::unwrap(current_index_option);
 
-                if let Option::Some(next_player_addr) = next_player_option {
-                    game.next_player = Option::Some(next_player_addr);
-                } else {
-                    // If no next player, something is wrong, or round should end.
-                    // `is_betting_round_concluded` should have caught this.
-                    game.showdown = true;
-                    game.next_player = Option::None;
+            // Update game state with the player's action
+            if player.current_bet > game.current_bet {
+                game.current_bet = player.current_bet; // Raise updates the current bet
+                game.highest_staker = Option::Some(caller);
+            }
+
+            // Write player state to storage BEFORE checking betting round completion
+            world.write_model(@player);
+
+            // Determine the next active player
+            let next_player_option: Option<ContractAddress> = self
+                .find_next_active_player(@game.players, current_index, @world);
+
+            if next_player_option.is_none() {
+                // No active players remain, resolve the round
+                game.showdown = true;
+            } else {
+                game.next_player = next_player_option;
+                
+                // Check if betting round is complete (more gas efficient) @kaylahray
+                if self.is_betting_round_complete(@game, @world) {
+                    // Reset betting state efficiently
+                    self.reset_betting_round(game_id, ref game, ref world);
                 }
             }
 
             world.write_model(@game);
+
+            if game.showdown {
+                let timestamp = get_block_timestamp();
+                let round_number = game.round_count;
+                let no_of_players = game.current_player_count;
+                let event = RoundEnded { game_id, timestamp, round_number, no_of_players };
+                world
+                    .write_member(
+                        Model::<GameStats>::ptr_from_keys(game_id),
+                        selector!("round_end_time"),
+                        timestamp,
+                    );
+                world.emit_event(@event);
+            }
+        }
+
+        /// betting round completion check @kaylahray
+        fn is_betting_round_complete(
+            self: @ContractState, 
+            game: @Game, 
+            world: @dojo::world::WorldStorage
+        ) -> bool {
+            let mut all_equal_bets = true;
+            let mut active_players = 0_u32;
+            
+            // Single pass through players to check betting status  @kaylahray
+            for player_addr in game.players.span() {
+                let p: Player = world.read_model(*player_addr);
+                if p.in_round {
+                    active_players += 1;
+                    if p.current_bet != *game.current_bet {
+                        all_equal_bets = false;
+                        break;
+                    }
+                }
+            };
+
+            // @kaylahray Betting round complete if all active players have equal bets and the game bet is not zero
+            all_equal_bets && active_players > 1 && *game.current_bet > 0
+        }
+
+        /// @kaylahray batch reset of betting round
+        fn reset_betting_round(
+            ref self: ContractState,
+            game_id: u64,
+            ref game: Game,
+            ref world: WorldStorage
+        ) {
+            // Reset game state
+            game.highest_staker = Option::None;
+            game.current_bet = 0;
+            
+            // Determine next phase
+            if game.community_cards.len() == 5 {
+                game.showdown = true;
+            } else {
+                game.community_dealing = true;
+            }
+            
+            // Batch reset all players' current_bet using write_member for better gas efficiency
+            for player_addr in game.players.span() {
+                world.write_member(
+                    Model::<Player>::ptr_from_keys(*player_addr),
+                    selector!("current_bet"),
+                    0_u256
+                );
+            }
         }
 
 

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -293,19 +293,23 @@ pub mod actions {
                 no_of_chips > game_current_bet, "Raise amount is less than the game's current bet.",
             );
 
+            // Validate bet spacing - raise amount must be in multiples of bet_spacing @kaylahray
+            assert!(
+                no_of_chips % params.bet_spacing.into() == 0,
+                "Raise amount must be in multiples of bet_spacing",
+            );
+
             // adjust this pot accordingly
             let mut game_pot = *game_pots.at(game_pots.len() - 1);
 
             let amount_to_call = game_current_bet - player.current_bet;
             let total_required = amount_to_call + no_of_chips;
             if game_pot == params.small_blind.into() {
-                assert!(
-                    no_of_chips > game_pot * 2, "Raise amount should be > twice the small blind.",
-                );
+                assert!(no_of_chips > game_pot * 2, "Raise must be > 2x blind.");
             }
 
-            assert!(no_of_chips > 0, "Raise amount must be greater than zero.");
-            assert!(player.chips >= total_required, "You don't have enough chips to raise.");
+            assert!(no_of_chips > 0, "Raise must be > 0.");
+            assert!(player.chips >= total_required, "Insufficient chips to raise.");
 
             if !self.adjust_stake(game_id, amount_to_call, ref player) {
                 player.chips -= total_required;
@@ -313,6 +317,15 @@ pub mod actions {
                 game_pot += total_required;
             }
             game_current_bet = player.current_bet;
+
+            // Set the player as highest staker after successful raise @kaylahray
+            let highest_staker_selector = selector!("highest_staker");
+            world
+                .write_member(
+                    Model::<Game>::ptr_from_keys(game_id),
+                    highest_staker_selector,
+                    Option::Some(player.id),
+                );
 
             let mut updated_game_pots: Array<u256> = ArrayTrait::new();
             let mut i = 0;
@@ -340,10 +353,31 @@ pub mod actions {
 
             let cb = selector!("current_bet");
             let mut game_current_bet = world.read_member(Model::<Game>::ptr_from_keys(game_id), cb);
+
             if amount < game_current_bet {
                 self.adjust_pot(game_id, ref player, game_current_bet);
+                world.write_model(@player);
+            } else {
+                // If all-in amount is >= current bet, player becomes highest staker @kaylahray
+                let new_bet = player.current_bet + amount;
+                if new_bet > game_current_bet {
+                    let highest_staker_selector = selector!("highest_staker");
+                    world
+                        .write_member(
+                            Model::<Game>::ptr_from_keys(game_id),
+                            highest_staker_selector,
+                            Option::Some(player.id),
+                        );
+                    // Update game's current bet @kaylahray
+                    world.write_member(Model::<Game>::ptr_from_keys(game_id), cb, new_bet);
+                }
+
+                // Update player state @kaylahray
+                player.current_bet += amount;
+                player.chips = 0;
+                world.write_model(@player);
             }
-            world.write_model(@player);
+
             self.after_play(player.id);
         }
 
@@ -530,6 +564,88 @@ pub mod actions {
         /// can't be const.
         fn world_default(self: @ContractState) -> WorldStorage {
             self.world(@"poker")
+        }
+
+        /// @Kaylahray Checks if betting round has concluded by verifying all active players have
+        /// equal bets
+        fn is_betting_round_concluded(
+            self: @ContractState, game_id: u64, world: @WorldStorage,
+        ) -> bool {
+            let game: Game = world.read_model(game_id);
+            let game_players = game.players.span();
+
+            let mut highest_bet: u256 = 0;
+            let mut active_player_count: u32 = 0;
+
+            // First pass: find the highest bet among active players
+            let mut i: u32 = 0;
+            while i < game_players.len() {
+                let player_addr = *game_players.at(i);
+                let player: Player = world.read_model(player_addr);
+
+                if player.in_round {
+                    active_player_count += 1;
+                    if player.current_bet > highest_bet {
+                        highest_bet = player.current_bet;
+                    }
+                }
+                i += 1;
+            };
+
+            if active_player_count <= 1 {
+                return true;
+            }
+
+            // Second pass: check if all active players who are not all-in have matched the highest
+            // bet
+            let mut all_matched = true;
+            let mut j: u32 = 0;
+            while j < game_players.len() {
+                let player_addr = *game_players.at(j);
+                let player: Player = world.read_model(player_addr);
+
+                if player.in_round {
+                    // Players who are all-in (0 chips) are exempt from matching
+                    if player.chips > 0 && player.current_bet != highest_bet {
+                        all_matched = false;
+                        break;
+                    }
+                }
+                j += 1;
+            };
+
+            all_matched
+        }
+
+        /// @kaylahray Resets betting values when a round concludes
+        fn reset_betting_round_values(self: @ContractState, game_id: u64, ref world: WorldStorage) {
+            let game: Game = world.read_model(game_id);
+            let game_players = game.players.span();
+
+            let mut i = 0;
+            while i < game_players.len() {
+                let player_addr = *game_players.at(i);
+                // Directly write to the player's current_bet field
+                world
+                    .write_member(
+                        Model::<Player>::ptr_from_keys(player_addr),
+                        selector!("current_bet"),
+                        0_u256,
+                    );
+                i += 1;
+            };
+
+            // Reset game's current_bet and highest_staker
+            world
+                .write_member(
+                    Model::<Game>::ptr_from_keys(game_id), selector!("current_bet"), 0_u256,
+                );
+            world
+                .write_member(
+                    Model::<Game>::ptr_from_keys(game_id),
+                    selector!("highest_staker"),
+                    Option::<ContractAddress>::None,
+                );
         }
 
         fn generate_id(self: @ContractState, target: felt252) -> u64 {
@@ -776,73 +892,50 @@ pub mod actions {
             );
         }
 
-        /// @Reentrancy, @Birdmannn
         fn after_play(ref self: ContractState, caller: ContractAddress) {
             let mut world = self.world_default();
-            let mut player: Player = world.read_model(caller);
+            let player: Player = world.read_model(caller);
             let (is_locked, game_id) = player.locked;
-
-            // Ensure the player is in a game
             assert(is_locked, 'Player not in game');
 
             let mut game: Game = world.read_model(game_id);
 
-            // Check if all community cards are dealt (5 cards in Texas Hold'em)
-            if game.community_cards.len() == 5 {
-                game.showdown = true;
-            }
+            let betting_concluded = self.is_betting_round_concluded(game_id, @world);
 
-            // Find the caller's index in the players array
-            let current_index_option: Option<usize> = self.find_player_index(@game.players, caller);
-            assert(current_index_option.is_some(), 'Caller not in game');
-            let current_index: usize = OptionTrait::unwrap(current_index_option);
+            if betting_concluded {
+                self.reset_betting_round_values(game_id, ref world);
+                game = world.read_model(game_id); // Reload game state
 
-            // Update game state with the player's action
-
-            // TODO: Crosscheck after_play, and adjust... may not be needed.
-            if player.current_bet > game.current_bet {
-                game.current_bet = player.current_bet; // Raise updates the current bet
-                game.highest_staker = Option::Some(caller);
-            } else if let Option::Some(highest_staker) = game.highest_staker {
-                if highest_staker == caller {
-                    // bet has gone round
-                    if game.community_cards.len() == 5 {
-                        game.showdown = true;
-                    } else {
-                        game.community_dealing = true;
-                    }
+                if game.community_cards.len() == 5 {
+                    game.showdown = true;
+                } else {
+                    game.community_dealing = true;
                 }
             }
 
-            world.write_model(@player);
-
-            // Determine the next active player or resolve the round
-            let next_player_option: Option<ContractAddress> = self
-                .find_next_active_player(@game.players, current_index, @world);
-
-            if next_player_option.is_none() {
-                // No active players remain, resolve the round
-                game.showdown = true;
+            // Now, set the next player
+            if game.showdown {
+                game.next_player = Option::None;
             } else {
-                game.next_player = next_player_option;
+                let current_index_option = self.find_player_index(@game.players, caller);
+                assert(current_index_option.is_some(), 'Caller not in game');
+                let current_index = OptionTrait::unwrap(current_index_option);
+                let next_player_option = self
+                    .find_next_active_player(@game.players, current_index, @world);
+
+                if let Option::Some(next_player_addr) = next_player_option {
+                    game.next_player = Option::Some(next_player_addr);
+                } else {
+                    // If no next player, something is wrong, or round should end.
+                    // `is_betting_round_concluded` should have caught this.
+                    game.showdown = true;
+                    game.next_player = Option::None;
+                }
             }
 
             world.write_model(@game);
-
-            if game.showdown {
-                let timestamp = get_block_timestamp();
-                let round_number = game.round_count;
-                let no_of_players = game.current_player_count;
-                let event = RoundEnded { game_id, timestamp, round_number, no_of_players };
-                world
-                    .write_member(
-                        Model::<GameStats>::ptr_from_keys(game_id),
-                        selector!("round_end_time"),
-                        timestamp,
-                    );
-                world.emit_event(@event);
-            }
         }
+
 
         fn find_player_index(
             self: @ContractState, players: @Array<ContractAddress>, player_address: ContractAddress,

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -292,13 +292,11 @@ pub mod actions {
                 no_of_chips > game_current_bet, "Raise amount is less than the game's current bet.",
             );
 
-         // Validate bet spacing - raise amount must be in multiples of bet_spacing @kaylahray
+            // Validate bet spacing - raise amount must be in multiples of bet_spacing @kaylahray
             let bet_spacing = params.bet_spacing;
             // Only the increment after current_bet needs to be multiple of bet_spacing. @kaylahray
             let raise_delta = no_of_chips - game_current_bet;
-            assert(
-                raise_delta % bet_spacing.into() == 0, 'Invalid raise spacing'
-            );
+            assert(raise_delta % bet_spacing.into() == 0, 'Invalid raise spacing');
 
             // adjust this pot accordingly
             let mut game_pot = *game_pots.at(game_pots.len() - 1);
@@ -320,9 +318,12 @@ pub mod actions {
 
             game_current_bet = player.current_bet;
             // @Kaylahray 👇
-           world.write_member(Model::<Game>::ptr_from_keys(game_id), selector!("highest_staker"), Option::Some(player.id));
-           
-            
+            world
+                .write_member(
+                    Model::<Game>::ptr_from_keys(game_id),
+                    selector!("highest_staker"),
+                    Option::Some(player.id),
+                );
 
             let mut updated_game_pots: Array<u256> = ArrayTrait::new();
             let mut i = 0;
@@ -339,7 +340,7 @@ pub mod actions {
             self.after_play(player.id);
         }
 
-       
+
         /// @dub_zn
         fn all_in(ref self: ContractState) {
             let mut world = self.world_default();
@@ -348,7 +349,7 @@ pub mod actions {
             // check the previous pot here.
             let game_id: u64 = *player.extract_current_game_id();
             let amount = player.chips;
-            
+
             let cb = selector!("current_bet");
             let game_current_bet = world.read_member(Model::<Game>::ptr_from_keys(game_id), cb);
 
@@ -358,23 +359,20 @@ pub mod actions {
 
             // @kaylahray Set highest_staker if this all-in creates new highest bet
             if player.current_bet > game_current_bet {
-                world.write_member(
-                    Model::<Game>::ptr_from_keys(game_id), 
-                    selector!("highest_staker"), 
-                    Option::Some(player.id)
-                );
-                world.write_member(
-                    Model::<Game>::ptr_from_keys(game_id), 
-                    cb, 
-                    player.current_bet
-                );
+                world
+                    .write_member(
+                        Model::<Game>::ptr_from_keys(game_id),
+                        selector!("highest_staker"),
+                        Option::Some(player.id),
+                    );
+                world.write_member(Model::<Game>::ptr_from_keys(game_id), cb, player.current_bet);
             }
 
             // Handle side pot creation if needed
             if amount < game_current_bet {
                 self.adjust_pot(game_id, ref player, game_current_bet);
             }
-            
+
             world.write_model(@player);
             self.after_play(player.id);
         }
@@ -808,7 +806,7 @@ pub mod actions {
             );
         }
 
-              /// @Reentrancy, @Birdmannn
+        /// @Reentrancy, @Birdmannn
         fn after_play(ref self: ContractState, caller: ContractAddress) {
             let mut world = self.world_default();
             let mut player: Player = world.read_model(caller);
@@ -847,7 +845,7 @@ pub mod actions {
                 game.showdown = true;
             } else {
                 game.next_player = next_player_option;
-                
+
                 // Check if betting round is complete (more gas efficient) @kaylahray
                 if self.is_betting_round_complete(@game, @world) {
                     // Reset betting state efficiently
@@ -874,13 +872,11 @@ pub mod actions {
 
         /// betting round completion check @kaylahray
         fn is_betting_round_complete(
-            self: @ContractState, 
-            game: @Game, 
-            world: @dojo::world::WorldStorage
+            self: @ContractState, game: @Game, world: @dojo::world::WorldStorage,
         ) -> bool {
             let mut all_equal_bets = true;
             let mut active_players = 0_u32;
-            
+
             // Single pass through players to check betting status  @kaylahray
             for player_addr in game.players.span() {
                 let p: Player = world.read_model(*player_addr);
@@ -893,35 +889,34 @@ pub mod actions {
                 }
             };
 
-            // @kaylahray Betting round complete if all active players have equal bets and the game bet is not zero
+            // @kaylahray Betting round complete if all active players have equal bets and the game
+            // bet is not zero
             all_equal_bets && active_players > 1 && *game.current_bet > 0
         }
 
         /// @kaylahray batch reset of betting round
         fn reset_betting_round(
-            ref self: ContractState,
-            game_id: u64,
-            ref game: Game,
-            ref world: WorldStorage
+            ref self: ContractState, game_id: u64, ref game: Game, ref world: WorldStorage,
         ) {
             // Reset game state
             game.highest_staker = Option::None;
             game.current_bet = 0;
-            
+
             // Determine next phase
             if game.community_cards.len() == 5 {
                 game.showdown = true;
             } else {
                 game.community_dealing = true;
             }
-            
+
             // Batch reset all players' current_bet using write_member for better gas efficiency
             for player_addr in game.players.span() {
-                world.write_member(
-                    Model::<Player>::ptr_from_keys(*player_addr),
-                    selector!("current_bet"),
-                    0_u256
-                );
+                world
+                    .write_member(
+                        Model::<Player>::ptr_from_keys(*player_addr),
+                        selector!("current_bet"),
+                        0_u256,
+                    );
             }
         }
 

--- a/poker-texas-hold-em/contract/src/systems/actions.cairo
+++ b/poker-texas-hold-em/contract/src/systems/actions.cairo
@@ -846,7 +846,7 @@ pub mod actions {
             } else {
                 game.next_player = next_player_option;
 
-                // Check if betting round is complete (more gas efficient) @kaylahray
+                // Check if betting round is complete  @kaylahray
                 if self.is_betting_round_complete(@game, @world) {
                     // Reset betting state efficiently
                     self.reset_betting_round(game_id, ref game, ref world);
@@ -870,35 +870,52 @@ pub mod actions {
             }
         }
 
-        /// betting round completion check @kaylahray
+        /// betting round completion check @kaylahray - Gas optimized version
+        /// Uses game state tracking instead of looping through players
         fn is_betting_round_complete(
             self: @ContractState, game: @Game, world: @dojo::world::WorldStorage,
         ) -> bool {
-            let mut all_equal_bets = true;
-            let mut active_players = 0_u32;
+            // If no highest staker is set, betting round is not complete
+            if game.highest_staker.is_none() {
+                return false;
+            }
 
-            // Single pass through players to check betting status  @kaylahray
-            for player_addr in game.players.span() {
-                let p: Player = world.read_model(*player_addr);
-                if p.in_round {
-                    active_players += 1;
-                    if p.current_bet != *game.current_bet {
-                        all_equal_bets = false;
-                        break;
+            // If current bet is 0, no betting has occurred yet
+            if *game.current_bet == 0 {
+                return false;
+            }
+
+            // Check if we've returned to the highest staker
+            // This means all other players have either folded, called, or gone all-in
+            match game.next_player {
+                Option::Some(next_player_addr) => {
+                    // If next player is the highest staker, the betting round is complete
+                    match game.highest_staker {
+                        Option::Some(staker) => next_player_addr == staker,
+                        Option::None => false
                     }
+                },
+                Option::None => {
+                    // No next player means only one player remains (others folded)
+                    true
                 }
-            };
-
-            // @kaylahray Betting round complete if all active players have equal bets and the game
-            // bet is not zero
-            all_equal_bets && active_players > 1 && *game.current_bet > 0
+            }
         }
 
         /// @kaylahray batch reset of betting round
         fn reset_betting_round(
             ref self: ContractState, game_id: u64, ref game: Game, ref world: WorldStorage,
         ) {
-            // Reset game state
+           
+            world
+                .write_member(
+                    Model::<Game>::ptr_from_keys(game_id),
+                    selector!("highest_staker"),
+                    Option::<ContractAddress>::None,
+                );
+            world.write_member(Model::<Game>::ptr_from_keys(game_id), selector!("current_bet"), 0_u256);
+
+            // Update local game reference
             game.highest_staker = Option::None;
             game.current_bet = 0;
 

--- a/poker-texas-hold-em/contract/src/tests/setup.cairo
+++ b/poker-texas-hold-em/contract/src/tests/setup.cairo
@@ -8,7 +8,7 @@ mod setup {
     use starknet::testing::{set_account_contract_address, set_contract_address};
     use poker::models::base::{
         m_Id, e_GameInitialized, e_CardDealt, e_HandCreated, e_HandResolved, e_RoundResolved,
-        e_PlayerJoined,
+        e_PlayerJoined, e_CommunityCardDealt,
     };
     use poker::models::deck::m_Deck;
     use poker::models::game::m_Game;
@@ -103,6 +103,7 @@ mod setup {
             TestResource::Event(e_HandResolved::TEST_CLASS_HASH),
             TestResource::Event(e_PlayerJoined::TEST_CLASS_HASH),
             TestResource::Event(e_RoundResolved::TEST_CLASS_HASH),
+            TestResource::Event(e_CommunityCardDealt::TEST_CLASS_HASH),
         ]
     }
 }

--- a/poker-texas-hold-em/contract/src/tests/setup.cairo
+++ b/poker-texas-hold-em/contract/src/tests/setup.cairo
@@ -14,6 +14,7 @@ mod setup {
     use poker::models::game::m_Game;
     use poker::models::hand::m_Hand;
     use poker::models::player::m_Player;
+    use core::zeroable::Zeroable;
 
 
     #[starknet::interface]

--- a/poker-texas-hold-em/contract/src/tests/test_actions.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_actions.cairo
@@ -365,10 +365,12 @@ mod tests {
         // Player 2 calls - should match game.current_bet
         set_contract_address(PLAYER_2());
         systems.actions.call();
-        
+
         // Check player 2 state after call
         let player_2_after_call: Player = world.read_model(PLAYER_2());
-        assert_eq!(player_2_after_call.current_bet, raise_amount.into(), "Player 2 didn't call correctly");
+        assert_eq!(
+            player_2_after_call.current_bet, raise_amount.into(), "Player 2 didn't call correctly",
+        );
 
         // Check if betting round completion would be detected at this point
         game = world.read_model(1);
@@ -379,7 +381,7 @@ mod tests {
         // Player 3 calls - this should complete the betting round and reset state
         set_contract_address(PLAYER_3());
         systems.actions.call();
-        
+
         // Check all player states immediately after the call
         game = world.read_model(1);
         let player_1: Player = world.read_model(PLAYER_1());
@@ -410,7 +412,7 @@ mod tests {
         set_contract_address(PLAYER_1());
         systems.actions.raise(raise_amount.into());
     }
-// @kaylahray Testing bet spacing success
+    // @kaylahray Testing bet spacing success
     #[test]
     fn test_bet_spacing_success() {
         // [Setup]
@@ -426,7 +428,7 @@ mod tests {
         let updated_game: Game = world.read_model(1);
         assert_eq!(updated_game.current_bet, raise_amount.into(), "Bet spacing success failed");
     }
-//   @kaylahray Testing all-in sets highest staker
+    //   @kaylahray Testing all-in sets highest staker
     #[test]
     fn test_all_in_sets_highest_staker() {
         // [Setup]

--- a/poker-texas-hold-em/contract/src/tests/test_actions.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_actions.cairo
@@ -91,10 +91,325 @@ mod tests {
         let (mut world, systems) = deploy_contracts(contracts);
         mock_poker_game(ref world);
 
+        // [Setup State] - Make sure it's PLAYER_1's turn but PLAYER_2 tries to check
+        let mut game: Game = world.read_model(1);
+        game.next_player = Option::Some(PLAYER_1()); // Explicitly set it's PLAYER_1's turn
+        world.write_model(@game);
+
         // [Execute]
         // PLAYER_2 trying to play when it's PLAYER_1's turn
         set_contract_address(PLAYER_2());
         systems.actions.check();
+    }
+
+    // ===== TESTS FOR HIGHEST STAKER AND BETTING ROUND LOGIC =====
+
+    #[test]
+    fn test_raise_sets_highest_staker() {
+        // [Setup] @kaylahray
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // [Setup State] - Set initial game state with current bet
+        let mut game: Game = world.read_model(1);
+        game.current_bet = 100;
+        world.write_model(@game);
+
+        let mut player_1: Player = world.read_model(PLAYER_1());
+        player_1.current_bet = 100; // Player has called the current bet
+        player_1.chips = 2000;
+        world.write_model(@player_1);
+
+        set_contract_address(player_1.id);
+
+        // [Execute] - Player 1 raises by 200 (total bet becomes 300)
+        systems.actions.raise(200);
+
+        // [Assert]
+        let game: Game = world.read_model(1);
+        let player_1_updated: Player = world.read_model(PLAYER_1());
+
+        assert_eq!(game.current_bet, 300, "Game current bet should be 300");
+        assert_eq!(
+            game.highest_staker, Option::Some(PLAYER_1()), "Player 1 should be highest staker",
+        );
+        assert_eq!(player_1_updated.current_bet, 300, "Player 1 current bet should be 300");
+        assert_eq!(player_1_updated.chips, 1800, "Player 1 should have 1800 chips left");
+    }
+
+    #[test]
+    fn test_all_in_sets_highest_staker_when_amount_greater_than_current_bet() {
+        // [Setup] @kaylahray
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // [Setup State]
+        let mut game: Game = world.read_model(1);
+        game.current_bet = 500;
+        world.write_model(@game);
+
+        let mut player_1: Player = world.read_model(PLAYER_1());
+        player_1.current_bet = 0; // Player hasn't bet yet
+        player_1.chips = 1000; // Player has 1000 chips
+        world.write_model(@player_1);
+
+        set_contract_address(player_1.id);
+
+        // [Execute] - Player 1 goes all-in with 1000 chips (more than current bet of 500)
+        systems.actions.all_in();
+
+        // [Assert]
+        let game: Game = world.read_model(1);
+        let player_1_updated: Player = world.read_model(PLAYER_1());
+
+        assert_eq!(game.current_bet, 1000, "Game current bet should be 1000");
+        assert_eq!(
+            game.highest_staker, Option::Some(PLAYER_1()), "Player 1 should be highest staker",
+        );
+        assert_eq!(player_1_updated.current_bet, 1000, "Player 1 current bet should be 1000");
+        assert_eq!(player_1_updated.chips, 0, "Player 1 should have 0 chips left");
+    }
+
+    #[test]
+    fn test_all_in_does_not_set_highest_staker_when_amount_less_than_current_bet() {
+        // [Setup] @kaylahray
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // [Setup State]
+        let mut game: Game = world.read_model(1);
+        game.current_bet = 1500;
+        game.highest_staker = Option::Some(PLAYER_2()); // Player 2 is current highest staker
+        world.write_model(@game);
+
+        let mut player_1: Player = world.read_model(PLAYER_1());
+        player_1.current_bet = 0;
+        player_1.chips = 1000; // Less than current bet
+        world.write_model(@player_1);
+
+        set_contract_address(player_1.id);
+
+        // [Execute] - Player 1 goes all-in with 1000 chips (less than current bet of 1500)
+        systems.actions.all_in();
+
+        // [Assert]
+        let game: Game = world.read_model(1);
+        let player_1_updated: Player = world.read_model(PLAYER_1());
+
+        assert_eq!(game.current_bet, 1500, "Game current bet should remain 1500");
+        assert_eq!(
+            game.highest_staker, Option::Some(PLAYER_2()), "Player 2 should remain highest staker",
+        );
+        assert_eq!(player_1_updated.current_bet, 1000, "Player 1 current bet should be 1000");
+        assert_eq!(player_1_updated.chips, 0, "Player 1 should have 0 chips left");
+    }
+
+    #[test]
+    fn test_betting_round_concludes_when_all_active_players_have_equal_bets() {
+        // [Setup] @kaylahray
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // [Setup State] - All players have equal bets
+        let mut game: Game = world.read_model(1);
+        game.current_bet = 500;
+        game.next_player = Option::Some(PLAYER_1()); // Set it's PLAYER_1's turn
+        world.write_model(@game);
+
+        let mut player_1: Player = world.read_model(PLAYER_1());
+        player_1.current_bet = 500;
+        player_1.chips = 1500;
+        world.write_model(@player_1);
+
+        let mut player_2: Player = world.read_model(PLAYER_2());
+        player_2.current_bet = 500;
+        player_2.chips = 4500;
+        world.write_model(@player_2);
+
+        let mut player_3: Player = world.read_model(PLAYER_3());
+        player_3.current_bet = 500;
+        player_3.chips = 4500;
+        world.write_model(@player_3);
+
+        set_contract_address(player_1.id);
+
+        // [Execute] - Player checks, which should trigger betting round conclusion check
+        systems.actions.check();
+
+        // [Assert] - Betting values should be reset
+        let game_updated: Game = world.read_model(1);
+        let player_1_updated: Player = world.read_model(PLAYER_1());
+        let player_2_updated: Player = world.read_model(PLAYER_2());
+        let player_3_updated: Player = world.read_model(PLAYER_3());
+
+        assert_eq!(game_updated.current_bet, 0, "Game current bet should be reset to 0");
+        assert_eq!(
+            game_updated.highest_staker, Option::None, "Highest staker should be reset to None",
+        );
+        assert_eq!(player_1_updated.current_bet, 0, "Player 1 current bet should be reset to 0");
+        assert_eq!(player_2_updated.current_bet, 0, "Player 2 current bet should be reset to 0");
+        assert_eq!(player_3_updated.current_bet, 0, "Player 3 current bet should be reset to 0");
+    }
+
+    #[test]
+    fn test_betting_round_does_not_conclude_when_players_have_unequal_bets() {
+        // [Setup] @kaylahray
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // [Setup State] - Players have unequal bets
+        let mut game: Game = world.read_model(1);
+        game.current_bet = 500;
+        game.highest_staker = Option::Some(PLAYER_2());
+        world.write_model(@game);
+
+        let mut player_1: Player = world.read_model(PLAYER_1());
+        player_1.current_bet = 300; // Different bet
+        player_1.chips = 1700;
+        world.write_model(@player_1);
+
+        let mut player_2: Player = world.read_model(PLAYER_2());
+        player_2.current_bet = 500;
+        player_2.chips = 4500;
+        world.write_model(@player_2);
+
+        set_contract_address(player_1.id);
+
+        // [Execute] - This should fail because player's bet doesn't match game's current bet
+        // When check is called with unequal bets, it should panic and betting round won't conclude
+
+        // We'll verify that the betting values are NOT reset by checking they remain the same
+        let game_before: Game = world.read_model(1);
+        let player_1_before: Player = world.read_model(PLAYER_1());
+        let player_2_before: Player = world.read_model(PLAYER_2());
+
+        // Since this will panic due to unequal bets, we can't actually call check
+        // But we can verify the state hasn't changed (betting round hasn't concluded)
+        assert_eq!(game_before.current_bet, 500, "Game current bet should remain 500");
+        assert_eq!(
+            game_before.highest_staker,
+            Option::Some(PLAYER_2()),
+            "Highest staker should remain Player 2",
+        );
+        assert_eq!(player_1_before.current_bet, 300, "Player 1 current bet should remain 300");
+        assert_eq!(player_2_before.current_bet, 500, "Player 2 current bet should remain 500");
+    }
+
+    #[test]
+    fn test_bet_spacing_validation_in_raise() {
+        // [Setup] @kaylahray
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // [Setup State] - Game with bet spacing of 20
+        let mut game: Game = world.read_model(1);
+        game.current_bet = 100;
+        let mut params = game.params;
+        params.bet_spacing = 20; // Set bet spacing to 20
+        game.params = params;
+        world.write_model(@game);
+
+        let mut player_1: Player = world.read_model(PLAYER_1());
+        player_1.current_bet = 100;
+        player_1.chips = 2000;
+        world.write_model(@player_1);
+
+        set_contract_address(player_1.id);
+
+        // [Execute] - Player raises by 40 (multiple of 20) - should succeed
+        systems.actions.raise(140); // Total bet becomes 240, raise amount is 140
+
+        // [Assert]
+        let player_1_updated: Player = world.read_model(PLAYER_1());
+        assert_eq!(
+            player_1_updated.current_bet, 240, "Raise should succeed with valid bet spacing",
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected: ("Raise amount must be in multiples of bet_spacing", 'ENTRYPOINT_FAILED'),
+    )]
+    fn test_bet_spacing_validation_fails_with_invalid_multiple() {
+        // [Setup] @kaylahray
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // [Setup State] - Game with bet spacing of 20
+        let mut game: Game = world.read_model(1);
+        game.current_bet = 100;
+        let mut params = game.params;
+        params.bet_spacing = 20; // Set bet spacing to 20
+        game.params = params;
+        world.write_model(@game);
+
+        let mut player_1: Player = world.read_model(PLAYER_1());
+        player_1.current_bet = 100;
+        player_1.chips = 2000;
+        world.write_model(@player_1);
+
+        set_contract_address(player_1.id);
+
+        // [Execute] - Player raises by 130 (not a multiple of 20) - should fail
+        systems.actions.raise(130);
+    }
+
+    #[test]
+    fn test_betting_round_with_all_in_players_exempt_from_bet_matching() {
+        // [Setup] @kaylahray
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // [Setup State] - One player all-in, others with equal bets
+        let mut game: Game = world.read_model(1);
+        game.current_bet = 1000;
+        game.next_player = Option::Some(PLAYER_2()); // Set it's PLAYER_2's turn
+        world.write_model(@game);
+
+        // Player 1 is all-in with less than current bet
+        let mut player_1: Player = world.read_model(PLAYER_1());
+        player_1.current_bet = 500; // Less than current bet
+        player_1.chips = 0; // All-in (0 chips)
+        world.write_model(@player_1);
+
+        // Players 2 and 3 have matched the current bet
+        let mut player_2: Player = world.read_model(PLAYER_2());
+        player_2.current_bet = 1000;
+        player_2.chips = 4000;
+        world.write_model(@player_2);
+
+        let mut player_3: Player = world.read_model(PLAYER_3());
+        player_3.current_bet = 1000;
+        player_3.chips = 4000;
+        world.write_model(@player_3);
+
+        set_contract_address(player_2.id);
+
+        // [Execute] - Player 2 checks, which should trigger betting round conclusion check
+        // Since all non-all-in players have equal bets, this should conclude the betting round
+        systems.actions.check();
+
+        // [Assert] - Betting values should be reset since betting round concluded
+        let game_updated: Game = world.read_model(1);
+        let player_1_updated: Player = world.read_model(PLAYER_1());
+        let player_2_updated: Player = world.read_model(PLAYER_2());
+        let player_3_updated: Player = world.read_model(PLAYER_3());
+
+        assert_eq!(game_updated.current_bet, 0, "Game current bet should be reset to 0");
+        assert_eq!(
+            game_updated.highest_staker, Option::None, "Highest staker should be reset to None",
+        );
+        assert_eq!(player_1_updated.current_bet, 0, "Player 1 current bet should be reset to 0");
+        assert_eq!(player_2_updated.current_bet, 0, "Player 2 current bet should be reset to 0");
+        assert_eq!(player_3_updated.current_bet, 0, "Player 3 current bet should be reset to 0");
     }
 
     #[test]
@@ -236,7 +551,11 @@ mod tests {
         let (mut world, systems) = deploy_contracts(contracts);
         mock_poker_game(ref world);
 
-        // [Setup State]
+        // [Setup State] - Ensure it's PLAYER_1's turn
+        let mut game: Game = world.read_model(1);
+        game.next_player = Option::Some(PLAYER_1());
+        world.write_model(@game);
+
         set_contract_address(PLAYER_1());
         systems.actions.fold();
 
@@ -350,7 +669,7 @@ mod tests {
             has_ended: false,
             current_round: 1,
             round_in_progress: true,
-            current_player_count: 2,
+            current_player_count: 3,
             players: array![PLAYER_1(), PLAYER_2(), PLAYER_3()],
             deck: array![],
             next_player: Option::Some(PLAYER_1()),

--- a/poker-texas-hold-em/contract/src/tests/test_actions.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_actions.cairo
@@ -91,325 +91,10 @@ mod tests {
         let (mut world, systems) = deploy_contracts(contracts);
         mock_poker_game(ref world);
 
-        // [Setup State] - Make sure it's PLAYER_1's turn but PLAYER_2 tries to check
-        let mut game: Game = world.read_model(1);
-        game.next_player = Option::Some(PLAYER_1()); // Explicitly set it's PLAYER_1's turn
-        world.write_model(@game);
-
         // [Execute]
         // PLAYER_2 trying to play when it's PLAYER_1's turn
         set_contract_address(PLAYER_2());
         systems.actions.check();
-    }
-
-    // ===== TESTS FOR HIGHEST STAKER AND BETTING ROUND LOGIC =====
-
-    #[test]
-    fn test_raise_sets_highest_staker() {
-        // [Setup] @kaylahray
-        let contracts = array![CoreContract::Actions];
-        let (mut world, systems) = deploy_contracts(contracts);
-        mock_poker_game(ref world);
-
-        // [Setup State] - Set initial game state with current bet
-        let mut game: Game = world.read_model(1);
-        game.current_bet = 100;
-        world.write_model(@game);
-
-        let mut player_1: Player = world.read_model(PLAYER_1());
-        player_1.current_bet = 100; // Player has called the current bet
-        player_1.chips = 2000;
-        world.write_model(@player_1);
-
-        set_contract_address(player_1.id);
-
-        // [Execute] - Player 1 raises by 200 (total bet becomes 300)
-        systems.actions.raise(200);
-
-        // [Assert]
-        let game: Game = world.read_model(1);
-        let player_1_updated: Player = world.read_model(PLAYER_1());
-
-        assert_eq!(game.current_bet, 300, "Game current bet should be 300");
-        assert_eq!(
-            game.highest_staker, Option::Some(PLAYER_1()), "Player 1 should be highest staker",
-        );
-        assert_eq!(player_1_updated.current_bet, 300, "Player 1 current bet should be 300");
-        assert_eq!(player_1_updated.chips, 1800, "Player 1 should have 1800 chips left");
-    }
-
-    #[test]
-    fn test_all_in_sets_highest_staker_when_amount_greater_than_current_bet() {
-        // [Setup] @kaylahray
-        let contracts = array![CoreContract::Actions];
-        let (mut world, systems) = deploy_contracts(contracts);
-        mock_poker_game(ref world);
-
-        // [Setup State]
-        let mut game: Game = world.read_model(1);
-        game.current_bet = 500;
-        world.write_model(@game);
-
-        let mut player_1: Player = world.read_model(PLAYER_1());
-        player_1.current_bet = 0; // Player hasn't bet yet
-        player_1.chips = 1000; // Player has 1000 chips
-        world.write_model(@player_1);
-
-        set_contract_address(player_1.id);
-
-        // [Execute] - Player 1 goes all-in with 1000 chips (more than current bet of 500)
-        systems.actions.all_in();
-
-        // [Assert]
-        let game: Game = world.read_model(1);
-        let player_1_updated: Player = world.read_model(PLAYER_1());
-
-        assert_eq!(game.current_bet, 1000, "Game current bet should be 1000");
-        assert_eq!(
-            game.highest_staker, Option::Some(PLAYER_1()), "Player 1 should be highest staker",
-        );
-        assert_eq!(player_1_updated.current_bet, 1000, "Player 1 current bet should be 1000");
-        assert_eq!(player_1_updated.chips, 0, "Player 1 should have 0 chips left");
-    }
-
-    #[test]
-    fn test_all_in_does_not_set_highest_staker_when_amount_less_than_current_bet() {
-        // [Setup] @kaylahray
-        let contracts = array![CoreContract::Actions];
-        let (mut world, systems) = deploy_contracts(contracts);
-        mock_poker_game(ref world);
-
-        // [Setup State]
-        let mut game: Game = world.read_model(1);
-        game.current_bet = 1500;
-        game.highest_staker = Option::Some(PLAYER_2()); // Player 2 is current highest staker
-        world.write_model(@game);
-
-        let mut player_1: Player = world.read_model(PLAYER_1());
-        player_1.current_bet = 0;
-        player_1.chips = 1000; // Less than current bet
-        world.write_model(@player_1);
-
-        set_contract_address(player_1.id);
-
-        // [Execute] - Player 1 goes all-in with 1000 chips (less than current bet of 1500)
-        systems.actions.all_in();
-
-        // [Assert]
-        let game: Game = world.read_model(1);
-        let player_1_updated: Player = world.read_model(PLAYER_1());
-
-        assert_eq!(game.current_bet, 1500, "Game current bet should remain 1500");
-        assert_eq!(
-            game.highest_staker, Option::Some(PLAYER_2()), "Player 2 should remain highest staker",
-        );
-        assert_eq!(player_1_updated.current_bet, 1000, "Player 1 current bet should be 1000");
-        assert_eq!(player_1_updated.chips, 0, "Player 1 should have 0 chips left");
-    }
-
-    #[test]
-    fn test_betting_round_concludes_when_all_active_players_have_equal_bets() {
-        // [Setup] @kaylahray
-        let contracts = array![CoreContract::Actions];
-        let (mut world, systems) = deploy_contracts(contracts);
-        mock_poker_game(ref world);
-
-        // [Setup State] - All players have equal bets
-        let mut game: Game = world.read_model(1);
-        game.current_bet = 500;
-        game.next_player = Option::Some(PLAYER_1()); // Set it's PLAYER_1's turn
-        world.write_model(@game);
-
-        let mut player_1: Player = world.read_model(PLAYER_1());
-        player_1.current_bet = 500;
-        player_1.chips = 1500;
-        world.write_model(@player_1);
-
-        let mut player_2: Player = world.read_model(PLAYER_2());
-        player_2.current_bet = 500;
-        player_2.chips = 4500;
-        world.write_model(@player_2);
-
-        let mut player_3: Player = world.read_model(PLAYER_3());
-        player_3.current_bet = 500;
-        player_3.chips = 4500;
-        world.write_model(@player_3);
-
-        set_contract_address(player_1.id);
-
-        // [Execute] - Player checks, which should trigger betting round conclusion check
-        systems.actions.check();
-
-        // [Assert] - Betting values should be reset
-        let game_updated: Game = world.read_model(1);
-        let player_1_updated: Player = world.read_model(PLAYER_1());
-        let player_2_updated: Player = world.read_model(PLAYER_2());
-        let player_3_updated: Player = world.read_model(PLAYER_3());
-
-        assert_eq!(game_updated.current_bet, 0, "Game current bet should be reset to 0");
-        assert_eq!(
-            game_updated.highest_staker, Option::None, "Highest staker should be reset to None",
-        );
-        assert_eq!(player_1_updated.current_bet, 0, "Player 1 current bet should be reset to 0");
-        assert_eq!(player_2_updated.current_bet, 0, "Player 2 current bet should be reset to 0");
-        assert_eq!(player_3_updated.current_bet, 0, "Player 3 current bet should be reset to 0");
-    }
-
-    #[test]
-    fn test_betting_round_does_not_conclude_when_players_have_unequal_bets() {
-        // [Setup] @kaylahray
-        let contracts = array![CoreContract::Actions];
-        let (mut world, systems) = deploy_contracts(contracts);
-        mock_poker_game(ref world);
-
-        // [Setup State] - Players have unequal bets
-        let mut game: Game = world.read_model(1);
-        game.current_bet = 500;
-        game.highest_staker = Option::Some(PLAYER_2());
-        world.write_model(@game);
-
-        let mut player_1: Player = world.read_model(PLAYER_1());
-        player_1.current_bet = 300; // Different bet
-        player_1.chips = 1700;
-        world.write_model(@player_1);
-
-        let mut player_2: Player = world.read_model(PLAYER_2());
-        player_2.current_bet = 500;
-        player_2.chips = 4500;
-        world.write_model(@player_2);
-
-        set_contract_address(player_1.id);
-
-        // [Execute] - This should fail because player's bet doesn't match game's current bet
-        // When check is called with unequal bets, it should panic and betting round won't conclude
-
-        // We'll verify that the betting values are NOT reset by checking they remain the same
-        let game_before: Game = world.read_model(1);
-        let player_1_before: Player = world.read_model(PLAYER_1());
-        let player_2_before: Player = world.read_model(PLAYER_2());
-
-        // Since this will panic due to unequal bets, we can't actually call check
-        // But we can verify the state hasn't changed (betting round hasn't concluded)
-        assert_eq!(game_before.current_bet, 500, "Game current bet should remain 500");
-        assert_eq!(
-            game_before.highest_staker,
-            Option::Some(PLAYER_2()),
-            "Highest staker should remain Player 2",
-        );
-        assert_eq!(player_1_before.current_bet, 300, "Player 1 current bet should remain 300");
-        assert_eq!(player_2_before.current_bet, 500, "Player 2 current bet should remain 500");
-    }
-
-    #[test]
-    fn test_bet_spacing_validation_in_raise() {
-        // [Setup] @kaylahray
-        let contracts = array![CoreContract::Actions];
-        let (mut world, systems) = deploy_contracts(contracts);
-        mock_poker_game(ref world);
-
-        // [Setup State] - Game with bet spacing of 20
-        let mut game: Game = world.read_model(1);
-        game.current_bet = 100;
-        let mut params = game.params;
-        params.bet_spacing = 20; // Set bet spacing to 20
-        game.params = params;
-        world.write_model(@game);
-
-        let mut player_1: Player = world.read_model(PLAYER_1());
-        player_1.current_bet = 100;
-        player_1.chips = 2000;
-        world.write_model(@player_1);
-
-        set_contract_address(player_1.id);
-
-        // [Execute] - Player raises by 40 (multiple of 20) - should succeed
-        systems.actions.raise(140); // Total bet becomes 240, raise amount is 140
-
-        // [Assert]
-        let player_1_updated: Player = world.read_model(PLAYER_1());
-        assert_eq!(
-            player_1_updated.current_bet, 240, "Raise should succeed with valid bet spacing",
-        );
-    }
-
-    #[test]
-    #[should_panic(
-        expected: ("Raise amount must be in multiples of bet_spacing", 'ENTRYPOINT_FAILED'),
-    )]
-    fn test_bet_spacing_validation_fails_with_invalid_multiple() {
-        // [Setup] @kaylahray
-        let contracts = array![CoreContract::Actions];
-        let (mut world, systems) = deploy_contracts(contracts);
-        mock_poker_game(ref world);
-
-        // [Setup State] - Game with bet spacing of 20
-        let mut game: Game = world.read_model(1);
-        game.current_bet = 100;
-        let mut params = game.params;
-        params.bet_spacing = 20; // Set bet spacing to 20
-        game.params = params;
-        world.write_model(@game);
-
-        let mut player_1: Player = world.read_model(PLAYER_1());
-        player_1.current_bet = 100;
-        player_1.chips = 2000;
-        world.write_model(@player_1);
-
-        set_contract_address(player_1.id);
-
-        // [Execute] - Player raises by 130 (not a multiple of 20) - should fail
-        systems.actions.raise(130);
-    }
-
-    #[test]
-    fn test_betting_round_with_all_in_players_exempt_from_bet_matching() {
-        // [Setup] @kaylahray
-        let contracts = array![CoreContract::Actions];
-        let (mut world, systems) = deploy_contracts(contracts);
-        mock_poker_game(ref world);
-
-        // [Setup State] - One player all-in, others with equal bets
-        let mut game: Game = world.read_model(1);
-        game.current_bet = 1000;
-        game.next_player = Option::Some(PLAYER_2()); // Set it's PLAYER_2's turn
-        world.write_model(@game);
-
-        // Player 1 is all-in with less than current bet
-        let mut player_1: Player = world.read_model(PLAYER_1());
-        player_1.current_bet = 500; // Less than current bet
-        player_1.chips = 0; // All-in (0 chips)
-        world.write_model(@player_1);
-
-        // Players 2 and 3 have matched the current bet
-        let mut player_2: Player = world.read_model(PLAYER_2());
-        player_2.current_bet = 1000;
-        player_2.chips = 4000;
-        world.write_model(@player_2);
-
-        let mut player_3: Player = world.read_model(PLAYER_3());
-        player_3.current_bet = 1000;
-        player_3.chips = 4000;
-        world.write_model(@player_3);
-
-        set_contract_address(player_2.id);
-
-        // [Execute] - Player 2 checks, which should trigger betting round conclusion check
-        // Since all non-all-in players have equal bets, this should conclude the betting round
-        systems.actions.check();
-
-        // [Assert] - Betting values should be reset since betting round concluded
-        let game_updated: Game = world.read_model(1);
-        let player_1_updated: Player = world.read_model(PLAYER_1());
-        let player_2_updated: Player = world.read_model(PLAYER_2());
-        let player_3_updated: Player = world.read_model(PLAYER_3());
-
-        assert_eq!(game_updated.current_bet, 0, "Game current bet should be reset to 0");
-        assert_eq!(
-            game_updated.highest_staker, Option::None, "Highest staker should be reset to None",
-        );
-        assert_eq!(player_1_updated.current_bet, 0, "Player 1 current bet should be reset to 0");
-        assert_eq!(player_2_updated.current_bet, 0, "Player 2 current bet should be reset to 0");
-        assert_eq!(player_3_updated.current_bet, 0, "Player 3 current bet should be reset to 0");
     }
 
     #[test]
@@ -551,11 +236,7 @@ mod tests {
         let (mut world, systems) = deploy_contracts(contracts);
         mock_poker_game(ref world);
 
-        // [Setup State] - Ensure it's PLAYER_1's turn
-        let mut game: Game = world.read_model(1);
-        game.next_player = Option::Some(PLAYER_1());
-        world.write_model(@game);
-
+        // [Setup State]
         set_contract_address(PLAYER_1());
         systems.actions.fold();
 
@@ -659,6 +340,111 @@ mod tests {
             updated_game.next_player == Option::Some(PLAYER_2()),
             "Next player should be PLAYER_2 after all-in",
         );
+    }
+
+    // [Betting Logic Tests] - Testing highest staker and bet reset functionality @kaylahray
+    #[test]
+    fn test_highest_staker_and_bet_reset() {
+        // [Setup]
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // Player 1 (PLAYER_1) raises @kaylahray
+        let mut game: Game = world.read_model(1);
+        let raise_amount = game.params.small_blind * 4; // Example raise = 40
+        set_contract_address(PLAYER_1());
+        systems.actions.raise(raise_amount.into());
+
+        // Check that highest_staker is set correctly
+        game = world.read_model(1);
+        assert!(game.highest_staker.is_some(), "Highest staker not set on raise");
+        assert_eq!(game.highest_staker.unwrap(), PLAYER_1(), "Incorrect highest staker");
+        assert_eq!(game.current_bet, raise_amount.into(), "Game bet not updated on raise");
+
+        // Player 2 calls - should match game.current_bet
+        set_contract_address(PLAYER_2());
+        systems.actions.call();
+        
+        // Check player 2 state after call
+        let player_2_after_call: Player = world.read_model(PLAYER_2());
+        assert_eq!(player_2_after_call.current_bet, raise_amount.into(), "Player 2 didn't call correctly");
+
+        // Check if betting round completion would be detected at this point
+        game = world.read_model(1);
+        let player_1_mid: Player = world.read_model(PLAYER_1());
+        // At this point: player1=40, player2=40, player3=0, game=40
+        // So betting round should NOT be complete yet
+
+        // Player 3 calls - this should complete the betting round and reset state
+        set_contract_address(PLAYER_3());
+        systems.actions.call();
+        
+        // Check all player states immediately after the call
+        game = world.read_model(1);
+        let player_1: Player = world.read_model(PLAYER_1());
+        let player_2: Player = world.read_model(PLAYER_2());
+        let player_3: Player = world.read_model(PLAYER_3());
+
+        // At this point, all players should have current_bet = 40, game.current_bet = 40
+        // The betting round should be complete and reset should have happened
+        assert!(game.highest_staker.is_none(), "Highest staker not reset");
+        assert_eq!(game.current_bet, 0, "Game current bet not reset");
+        assert_eq!(player_1.current_bet, 0, "Player 1 bet not reset");
+        assert_eq!(player_2.current_bet, 0, "Player 2 bet not reset");
+        assert_eq!(player_3.current_bet, 0, "Player 3 bet not reset");
+    }
+
+    // @kaylahray Testing bet spacing logic
+    #[test]
+    #[should_panic(expected: ('Invalid raise spacing', 'ENTRYPOINT_FAILED'))]
+    fn test_bet_spacing_fail() {
+        // [Setup]
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        let game: Game = world.read_model(1);
+        // Not a multiple of bet_spacing (which is small_blind)
+        let raise_amount = game.params.small_blind * 2 + 1;
+        set_contract_address(PLAYER_1());
+        systems.actions.raise(raise_amount.into());
+    }
+// @kaylahray Testing bet spacing success
+    #[test]
+    fn test_bet_spacing_success() {
+        // [Setup]
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        let game: Game = world.read_model(1);
+        let raise_amount = game.params.small_blind * 4; // 40 is multiple of bet_spacing (20)
+        set_contract_address(PLAYER_1());
+        systems.actions.raise(raise_amount.into());
+
+        let updated_game: Game = world.read_model(1);
+        assert_eq!(updated_game.current_bet, raise_amount.into(), "Bet spacing success failed");
+    }
+//   @kaylahray Testing all-in sets highest staker
+    #[test]
+    fn test_all_in_sets_highest_staker() {
+        // [Setup]
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // Player 1 goes all-in
+        set_contract_address(PLAYER_1());
+        systems.actions.all_in();
+
+        let game: Game = world.read_model(1);
+        let player_1: Player = world.read_model(PLAYER_1());
+
+        assert!(game.highest_staker.is_some(), "Highest staker not set on all-in");
+        assert_eq!(game.highest_staker.unwrap(), player_1.id, "Incorrect highest staker on all-in");
+        assert_eq!(game.current_bet, player_1.current_bet, "Game bet not updated on all-in");
+        assert_eq!(player_1.chips, 0, "Player should have 0 chips after all-in");
     }
 
     // [Mocks]

--- a/poker-texas-hold-em/contract/src/tests/test_actions.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_actions.cairo
@@ -549,10 +549,16 @@ pub mod tests {
         let updated_game: Game = world.read_model(1);
 
         assert_eq!(updated_player.chips, 0, "Player chips should be 0 after all-in");
-        assert_eq!(updated_player.current_bet, 135, "Player current_bet should equal all-in amount");
-        assert_eq!(updated_game.current_bet, 135, "Game current_bet should be updated to all-in amount");
+        assert_eq!(
+            updated_player.current_bet, 135, "Player current_bet should equal all-in amount",
+        );
+        assert_eq!(
+            updated_game.current_bet, 135, "Game current_bet should be updated to all-in amount",
+        );
         assert!(updated_game.highest_staker.is_some(), "Highest staker should be set");
-        assert_eq!(updated_game.highest_staker.unwrap(), PLAYER_1(), "Highest staker should be PLAYER_1");
+        assert_eq!(
+            updated_game.highest_staker.unwrap(), PLAYER_1(), "Highest staker should be PLAYER_1",
+        );
     }
 
     // @kaylahray Community dealing tests - Testing community card dealing functionality
@@ -568,7 +574,10 @@ pub mod tests {
 
         // Check that community_dealing is enabled after betting round completion
         let game_after_betting: Game = world.read_model(1);
-        assert!(game_after_betting.community_dealing, "Community dealing should be enabled after betting round");
+        assert!(
+            game_after_betting.community_dealing,
+            "Community dealing should be enabled after betting round",
+        );
 
         // Now deal three community cards (the flop)
         let card1 = Card { suit: 4, value: 1 }; // Hearts Ace
@@ -581,8 +590,13 @@ pub mod tests {
 
         // Verify all three cards were dealt
         let game_after_dealing: Game = world.read_model(1);
-        assert_eq!(game_after_dealing.community_cards.len(), 3, "Should have 3 community cards after flop");
-        assert!(!game_after_dealing.community_dealing, "Community dealing should be disabled after 3 cards");
+        assert_eq!(
+            game_after_dealing.community_cards.len(), 3, "Should have 3 community cards after flop",
+        );
+        assert!(
+            !game_after_dealing.community_dealing,
+            "Community dealing should be disabled after 3 cards",
+        );
     }
 
     #[test]
@@ -631,14 +645,21 @@ pub mod tests {
 
         // Verify betting can resume - community_dealing should be false, allowing betting
         let game_after_dealing: Game = world.read_model(1);
-        assert!(!game_after_dealing.community_dealing, "Community dealing should be disabled, allowing betting");
+        assert!(
+            !game_after_dealing.community_dealing,
+            "Community dealing should be disabled, allowing betting",
+        );
 
         // Test that a player can now make a bet (check)
         set_contract_address(PLAYER_1());
         systems.actions.check(); // Should succeed
 
         let game_after_check: Game = world.read_model(1);
-        assert_eq!(game_after_check.next_player, Option::Some(PLAYER_2()), "Betting should resume normally");
+        assert_eq!(
+            game_after_check.next_player,
+            Option::Some(PLAYER_2()),
+            "Betting should resume normally",
+        );
     }
 
     //  Trying two functions 👇.
@@ -675,7 +696,6 @@ pub mod tests {
         set_contract_address(PLAYER_1());
         systems.actions.call(); // Should panic with 'INVALID CALL'
     }
-
 
 
     // Helper function to simulate a complete betting round

--- a/poker-texas-hold-em/contract/src/tests/test_actions.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_actions.cairo
@@ -9,9 +9,10 @@ mod tests {
     };
     use poker::models::game::{Game, GameTrait};
     use poker::models::player::{Player, PlayerTrait};
+    use poker::models::card::{Card, Suits, Royals};
     use poker::traits::game::get_default_game_params;
     use poker::systems::interface::{IActionsDispatcher, IActionsDispatcherTrait};
-    use poker::tests::setup::setup::{CoreContract, deploy_contracts};
+    use poker::tests::setup::setup::{CoreContract, deploy_contracts, Systems};
     use starknet::ContractAddress;
     use starknet::testing::{set_account_contract_address, set_contract_address};
 
@@ -447,6 +448,189 @@ mod tests {
         assert_eq!(game.highest_staker.unwrap(), player_1.id, "Incorrect highest staker on all-in");
         assert_eq!(game.current_bet, player_1.current_bet, "Game bet not updated on all-in");
         assert_eq!(player_1.chips, 0, "Player should have 0 chips after all-in");
+    }
+
+    // @kaylahray Testing all-in works regardless of bet spacing
+    #[test]
+    fn test_all_in_ignores_bet_spacing() {
+        // [Setup]
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // Set up game with bet_spacing requirement (default is small_blind = 10)
+        let game: Game = world.read_model(1);
+        let bet_spacing = game.params.bet_spacing; // Default is 20
+
+        // Set player's chips to an amount that's NOT a multiple of bet_spacing
+        let mut player_1: Player = world.read_model(PLAYER_1());
+        player_1.chips = 135; // 135 % 20 = 15, so NOT a multiple of bet_spacing
+        world.write_model(@player_1);
+
+        // Set game current_bet to 0 for simplicity
+        let mut game_updated: Game = world.read_model(1);
+        game_updated.current_bet = 0;
+        world.write_model(@game_updated);
+
+        // [Execute] - All-in should succeed regardless of bet spacing
+        set_contract_address(PLAYER_1());
+        systems.actions.all_in();
+
+        // [Assert] - All-in worked despite chips not being multiple of bet_spacing
+        let updated_player: Player = world.read_model(PLAYER_1());
+        let updated_game: Game = world.read_model(1);
+
+        assert_eq!(updated_player.chips, 0, "Player chips should be 0 after all-in");
+        assert_eq!(updated_player.current_bet, 135, "Player current_bet should equal all-in amount");
+        assert_eq!(updated_game.current_bet, 135, "Game current_bet should be updated to all-in amount");
+        assert!(updated_game.highest_staker.is_some(), "Highest staker should be set");
+        assert_eq!(updated_game.highest_staker.unwrap(), PLAYER_1(), "Highest staker should be PLAYER_1");
+    }
+
+    // @kaylahray Community dealing tests - Testing community card dealing functionality
+    #[test]
+    fn test_community_dealing_after_betting_round() {
+        // [Setup]
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // Complete a betting round
+        feign_betting_round(ref world, systems.actions);
+
+        // Check that community_dealing is enabled after betting round completion
+        let game_after_betting: Game = world.read_model(1);
+        assert!(game_after_betting.community_dealing, "Community dealing should be enabled after betting round");
+
+        // Now deal three community cards (the flop)
+        let card1 = Card { suit: 4, value: 1 }; // Hearts Ace
+        let card2 = Card { suit: 1, value: 13 }; // Spades King
+        let card3 = Card { suit: 3, value: 12 }; // Diamonds Queen
+
+        systems.actions.deal_community_card(card1, 1);
+        systems.actions.deal_community_card(card2, 1);
+        systems.actions.deal_community_card(card3, 1);
+
+        // Verify all three cards were dealt
+        let game_after_dealing: Game = world.read_model(1);
+        assert_eq!(game_after_dealing.community_cards.len(), 3, "Should have 3 community cards after flop");
+        assert!(!game_after_dealing.community_dealing, "Community dealing should be disabled after 3 cards");
+    }
+
+    #[test]
+    #[should_panic(expected: ('INVALID DEALING', 'ENTRYPOINT_FAILED'))]
+    fn test_fourth_community_card_dealing_panics() {
+        // [Setup]
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // Complete a betting round first
+        feign_betting_round(ref world, systems.actions);
+
+        // Deal three valid community cards
+        let card1 = Card { suit: 4, value: 1 }; // Hearts Ace
+        let card2 = Card { suit: 1, value: 13 }; // Spades King
+        let card3 = Card { suit: 3, value: 12 }; // Diamonds Queen
+        let card4 = Card { suit: 2, value: 11 }; // Clubs Jack
+
+        systems.actions.deal_community_card(card1, 1);
+        systems.actions.deal_community_card(card2, 1);
+        systems.actions.deal_community_card(card3, 1);
+
+        // Fourth card should panic
+        systems.actions.deal_community_card(card4, 1);
+    }
+
+    #[test]
+    fn test_betting_resumes_after_community_cards() {
+        // [Setup]
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // Complete a betting round
+        feign_betting_round(ref world, systems.actions);
+
+        // Deal three community cards
+        let card1 = Card { suit: 4, value: 1 }; // Hearts Ace
+        let card2 = Card { suit: 1, value: 13 }; // Spades King
+        let card3 = Card { suit: 3, value: 12 }; // Diamonds Queen
+
+        systems.actions.deal_community_card(card1, 1);
+        systems.actions.deal_community_card(card2, 1);
+        systems.actions.deal_community_card(card3, 1);
+
+        // Verify betting can resume - community_dealing should be false, allowing betting
+        let game_after_dealing: Game = world.read_model(1);
+        assert!(!game_after_dealing.community_dealing, "Community dealing should be disabled, allowing betting");
+
+        // Test that a player can now make a bet (check)
+        set_contract_address(PLAYER_1());
+        systems.actions.check(); // Should succeed
+
+        let game_after_check: Game = world.read_model(1);
+        assert_eq!(game_after_check.next_player, Option::Some(PLAYER_2()), "Betting should resume normally");
+    }
+
+    //  Trying two functions 👇.
+    
+    #[test]
+    #[should_panic(expected: ('INVALID CALL', 'ENTRYPOINT_FAILED'))]
+    fn test_betting_fails_when_community_dealing_active() {
+        // [Setup]
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        // Complete a betting round to enable community_dealing
+        feign_betting_round(ref world, systems.actions);
+
+        // Verify community_dealing is active
+        let game_after_betting: Game = world.read_model(1);
+        assert!(game_after_betting.community_dealing, "Community dealing should be active");
+
+        // Try to make a bet while community_dealing is active - should panic
+        set_contract_address(PLAYER_1());
+        systems.actions.check(); // Should panic with 'INVALID CALL'
+    }
+
+    #[test]
+    #[should_panic(expected: ('INVALID CALL', 'ENTRYPOINT_FAILED'))]
+    fn test_call_fails_when_community_dealing_active() {
+        let contracts = array![CoreContract::Actions];
+        let (mut world, systems) = deploy_contracts(contracts);
+        mock_poker_game(ref world);
+
+        feign_betting_round(ref world, systems.actions);
+
+        set_contract_address(PLAYER_1());
+        systems.actions.call(); // Should panic with 'INVALID CALL'
+    }
+
+
+
+    // Helper function to simulate a complete betting round
+    fn feign_betting_round(ref world: WorldStorage, actions: IActionsDispatcher) {
+        // Player 1 raises
+        let game: Game = world.read_model(1);
+        let raise_amount = game.params.small_blind * 4; // 40
+        set_contract_address(PLAYER_1());
+        actions.raise(raise_amount.into());
+
+        // Player 2 calls
+        set_contract_address(PLAYER_2());
+        actions.call();
+
+        // Player 3 calls - this completes the betting round
+        set_contract_address(PLAYER_3());
+        actions.call();
+
+        // Verify betting round is complete and reset has occurred
+        let game_after_betting: Game = world.read_model(1);
+        assert!(game_after_betting.highest_staker.is_none(), "Betting round should be complete");
+        assert_eq!(game_after_betting.current_bet, 0, "Current bet should be reset");
+        assert!(game_after_betting.community_dealing, "Community dealing should be enabled");
     }
 
     // [Mocks]

--- a/poker-texas-hold-em/contract/src/tests/test_hand_compare.cairo
+++ b/poker-texas-hold-em/contract/src/tests/test_hand_compare.cairo
@@ -38,6 +38,7 @@ mod tests {
             kicker_split: kicker_split,
             min_amount_of_chips: 2000,
             blind_spacing: 10,
+            bet_spacing: 20,
             showdown_type: ShowdownType::Gathered,
         }
     }

--- a/poker-texas-hold-em/contract/src/traits/game.cairo
+++ b/poker-texas-hold-em/contract/src/traits/game.cairo
@@ -13,6 +13,7 @@ const MIN_BIG_BLIND: u64 = 2;
 const MIN_NO_OF_DECKS: u8 = 1;
 const MIN_AMOUNT_OF_CHIPS: u256 = 10;
 const MIN_BLIND_SPACING: u16 = 1;
+const MIN_BET_SPACING: u256 = 1;
 
 #[generate_trait]
 pub impl GameImpl of GameTrait {
@@ -36,6 +37,7 @@ pub impl GameImpl of GameTrait {
                     GameErrors::INVALID_GAME_PARAMS,
                 );
                 assert(params.blind_spacing >= MIN_BLIND_SPACING, GameErrors::INVALID_GAME_PARAMS);
+                assert(params.bet_spacing >= MIN_BET_SPACING, GameErrors::INVALID_GAME_PARAMS);
                 params
             },
             Option::None => get_default_game_params(),
@@ -72,6 +74,7 @@ fn get_default_game_params() -> GameParams {
         kicker_split: true,
         min_amount_of_chips: 100,
         blind_spacing: 10,
+        bet_spacing: 20,
         showdown_type: Default::default(),
     }
 }


### PR DESCRIPTION
Closes #193 
##  Highest Staker Logic

### **Requirement**

* The `highest_staker` should be updated:

  * During a **raise** operation.
  * During an **all\_in** operation **only if** the all-in amount is **greater than** the game’s current bet.


### **Implementation**

* The `raise()` function in `actions.cairo` now **sets** `highest_staker`.
* The `all_in()` function includes logic to update `highest_staker` **only when** the all-in amount exceeds `game.current_bet`.

### **Tests**

* **`test_raise_sets_highest_staker`**
  Confirms that when a player successfully raises, they are correctly set as the `highest_staker` in the game state.

* **`test_all_in_sets_highest_staker_when_amount_greater_than_current_bet`**
  Verifies that a player who goes all-in with an amount **greater than** the current table bet becomes the new `highest_staker`.

* **`test_all_in_does_not_set_highest_staker_when_amount_less_than_current_bet`**
  Ensures that a player who goes all-in with an amount **less than** the current bet does **not** become the `highest_staker`.


## Resetting Values After a Betting Round

### **Requirement**

* At the end of a betting round:

  * Reset `current_bet` for **all players** and the **game**.
  * Reset `game.highest_staker` to `None`.
* This must happen **automatically** when betting concludes and must be **tested**.

### **Implementation**
- Created two new internal functions, `is_betting_round_concluded` and `reset_betting_round_values`. This cleanly separates the logic for checking if a round has ended (all active, non-all-in players have equal bets) and the logic for resetting the game state (player bets, game bets, highest staker) for the next phase of the round.

* This function is called inside `after_play()` when `is_betting_round_concluded()` returns `true`.

### **Tests**

* **`test_betting_round_concludes_when_all_active_players_have_equal_bets`**
  Ensures that when all active players have equal bets and a non-betting action (e.g., `check`) occurs, the round concludes and all values (`current_bet`, `highest_staker`) are reset.

* **`test_betting_round_does_not_conclude_when_players_have_unequal_bets`**
  A control test confirming that if players have **unequal** bets, the betting round **does not** conclude, and the game state remains unchanged.

* **`test_betting_round_with_all_in_players_exempt_from_bet_matching`**
  Verifies that **all-in players** (who can’t raise further) **do not block** the round from ending. It confirms that the round ends when all other active players match the highest bet.

## Bet Spacing Validation

### **Requirement**

* Any **raise amount** must be a **multiple** of `game_params.bet_spacing`.
* This constraint must be **strictly enforced and tested**.

### **Implementation**

* The `raise()` function includes an assertion:

  ```cairo
  assert(raise_amount % game.params.bet_spacing == 0, 'Raise amount must be in multiples of bet_spacing');
  ```
This ensures invalid raises are rejected at runtime.

###  **Tests**

* **`test_bet_spacing_validation_in_raise`**
  Confirms that a player can successfully raise when their amount is a valid multiple of `game.params.bet_spacing`.

* **`test_bet_spacing_validation_fails_with_invalid_multiple`**
  Ensures that any raise not adhering to the bet spacing rule **correctly panics** and is not accepted.

<img width="948" height="348" alt="image" src="https://github.com/user-attachments/assets/bb4dd22c-55a3-448b-8197-3d467cf758b6" />


